### PR TITLE
Fix race condition on search and campaign filter

### DIFF
--- a/campaignresourcecentre/campaigns/templates/campaign_hub.html
+++ b/campaignresourcecentre/campaigns/templates/campaign_hub.html
@@ -120,10 +120,10 @@
          * Gets the topic if there is one.
          * If there is no topic, topic is "ALL".
          * Creates a string from the topic and sort by values.
-         * Removes the class of selected.
-         * Applies the class selected to the current link.
          * Creates a new XMLHttp request.
          * Outputs the HTML required for the requested campaigns.
+         * Removes the class of selected.
+         * Applies the class selected to the current link.
          */
         function renderTopic(e) {
             e.preventDefault();
@@ -139,23 +139,22 @@
                 filterTopic = "ALL";
             }
             topicQueryString += "topic=" + filterTopic + "&sort=" + sortBy;
-            
-            const campaigns = document.getElementById("campaigns");
-            for (let i=0; i<filters.length; i++) {
-                filters[i].classList.remove("selected");
-            }
-            this.classList.add("selected");
+
             const xhttp_topic = new XMLHttpRequest();
             xhttp_topic.onreadystatechange = function() {
                 if (this.readyState == 4){
                     if(this.status == 200) {
+                        const campaigns = document.getElementById("campaigns");
                         campaigns.outerHTML = this.responseText;
                     }
                 }
             }
+            for (let i=0; i<filters.length; i++) {
+                filters[i].classList.remove("selected");
+            }
+            this.classList.add("selected");
             xhttp_topic.open("GET", "/render_topic/?" + topicQueryString);
             xhttp_topic.send();
-            console.log("final topic query " + topicQueryString);
             return filterTopic;
         }
 
@@ -174,18 +173,18 @@
         function submit(element) {
             sortBy = element.value;
             const sortQueryString = "topic=" + filterTopic + "&sort=" + sortBy;
-            const topics = document.getElementById("campaigns");
+            
             const xhttp_sort = new XMLHttpRequest();
             xhttp_sort.onreadystatechange = function() {
                 if (this.readyState == 4){
                     if(this.status == 200) {
+                        const topics = document.getElementById("campaigns");
                         topics.outerHTML = this.responseText;
                     }
                 }
             }
             xhttp_sort.open("GET", "/render_topic/?" + sortQueryString);
             xhttp_sort.send();
-            console.log("final sort query " + sortQueryString);
             return sortBy;
         }
         

--- a/campaignresourcecentre/core/templates/molecules/search-result/refresh-search.html
+++ b/campaignresourcecentre/core/templates/molecules/search-result/refresh-search.html
@@ -1,4 +1,5 @@
 {% load filters %}
+{% load wagtailcore_tags %}
 
 <div class="govuk-grid-column-three-quarters" id="search-result">
     <div class="govuk-grid-column">
@@ -62,11 +63,11 @@
         </div>
     {% endif %}
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group" id="sort">
         <label class="govuk-label sort-by-label" for="sort">
             Sort by
         </label>
-        <select class="govuk-select" id="sort" name="sort" onchange="submitForm()">
+        <select class="govuk-select" id="sort" name="sort" onchange="submitSortby(this)">
             <option value="relevant" {% if sort == 'relevant'%}selected{% endif %}>Most relevant</option>
             <option value="newest" {% if sort == 'newest'%}selected{% endif %}>Newest</option>
             <option value="oldest" {% if sort == 'oldest'%}selected{% endif %}>Oldest</option>

--- a/campaignresourcecentre/resources/templates/search.html
+++ b/campaignresourcecentre/resources/templates/search.html
@@ -164,15 +164,28 @@
             document.getElementById("search-field").focus()
         }
 
+        /**
+         * Gets the search value from the form.
+         * Creates a query string from the search value.
+         * Creates a new XMLHttp request.
+         * Outputs the HTML required for the requested campaigns.
+         */
+
+        // Initialise default values
+        let sortBy = "";
+        let queryString = "";
+
         function submitForm() {
-            if("URLSearchParams" in window)
-            {
-                const queryString = new URLSearchParams(new FormData(document.getElementById("resource-filter-form"))).toString();
-                const searchForm = document.getElementById("search-result");
+            if("URLSearchParams" in window){
+                queryString = "";
+                const filterForm = document.getElementById("resource-filter-form");
+                queryString = new URLSearchParams(new FormData(filterForm)).toString();
+                queryString += "&sort=" + sortBy;
                 const xhttp_ss = new XMLHttpRequest();
                 xhttp_ss.onreadystatechange = function() {
                     if (this.readyState == 4){
                         if(this.status == 200) {
+                            const searchForm = document.getElementById("search-result");
                             searchForm.outerHTML = this.responseText;
                         }
                     }
@@ -184,6 +197,7 @@
                 const button = document.getElementById("filter-search");
                 button.click();
             }
+            return queryString;
         }
 
         function unCheckSubmitForm(elem) {
@@ -198,6 +212,40 @@
                 //resubmit the filter
                 submitForm();
             }
+        }
+
+
+        /**
+         * Gets the sort by value from the drop down list.
+         * Creates a query string.
+         * Creates a new XMLHttp request.
+         * Outputs the HTML required for the requested campaigns.
+         */
+         function submitSortby(element) {
+            sortBy = element.value;
+            // Check if query string has a value, set to current URL query if not.
+            if(!queryString) {
+                url = window.location.href;
+                queryString = url.split('?')[1];
+            }
+            // Check if query string already includes sort value, remove sort value if it does.
+            if(queryString.includes("&sort=")) {
+                const querySplit = queryString.split("&sort=")[0];
+                queryString = querySplit;
+            }
+            const sortQueryString = queryString + "&sort=" + sortBy;
+            const xhttp_sort = new XMLHttpRequest();
+            xhttp_sort.onreadystatechange = function() {
+                if (this.readyState == 4){
+                    if(this.status == 200) {
+                        const topics = document.getElementById("search-result");
+                        topics.outerHTML = this.responseText;
+                    }
+                }
+            }
+            xhttp_sort.open("GET", "/render_search/?" + sortQueryString);
+            xhttp_sort.send();
+            return sortBy;
         }
     </script>
 {% endblock %}


### PR DESCRIPTION
When the filters on the search for resources are clicked, the new results refresh prior to the user clicking another filter to prevent a race condition. Previously, the user could click two or more filters in quick succession which then showed incorrect results or filters. The same issue also affects the campaigns filter by topic.
Fix the sort by on the search resources page.
Jira ticket: CV-434 page refresh, CV-685 sort by on search results page
