### PR TITLE
Search filter keyboard access

### DIFF
--- a/campaignresourcecentre/core/templates/molecules/search-result/refresh-search.html
+++ b/campaignresourcecentre/core/templates/molecules/search-result/refresh-search.html
@@ -22,10 +22,10 @@
                                 <div class="taxonomy-tags__parent">Topic</div>
                                 {% for child in taxonomy.children %}
                                     {% if facets_queryset|taxonomies_get:taxonomy.code|code_includes:child.code %}
-                                        <div class="taxonomy-tags__child">
-                                            <strong aria-hidden="true" class="taxonomy-tags__remove" value="{{child.code}}-input" parent="{{taxonomy.code}}" onclick="unCheckSubmitForm(this)">✕</strong>
+                                        <button class="taxonomy-tags__child" class="taxonomy-tags__remove" value="{{child.code}}-input" parent="{{taxonomy.code}}" onclick="return unCheckSubmitForm(this)">
+                                            <strong aria-hidden="true" class="taxonomy-tags__remove">✕</strong>
                                             <span class="sr-only">Remove </span><span class="taxonomy-tags__child-label">{{child.label}}</span>
-                                        </div>
+                                        </button>
                                     {% endif %}
                                 {% endfor %}
                             {% endif %}    
@@ -46,10 +46,10 @@
                                         </label>
                                     </div>
                                     -->
-                                    <div class="taxonomy-tags__child">
-                                        <strong aria-hidden="true" class="taxonomy-tags__remove" value="{{child.code}}-input" parent="{{taxonomy.code}}" onclick="unCheckSubmitForm(this)">✕</strong>
+                                    <button class="taxonomy-tags__child"        class="taxonomy-tags__remove" value="{{child.code}}-input" parent="{{taxonomy.code}}" onclick="return unCheckSubmitForm(this)">
+                                        <strong aria-hidden="true" class="taxonomy-tags__remove">✕</strong>
                                         <span class="sr-only">Remove </span><span class="taxonomy-tags__child-label">{{child.label}}</span>
-                                    </div>
+                                    </button>
                                     {% endif %}
                                 {% endfor %}
                             {% endif %}

--- a/campaignresourcecentre/resources/templates/search.html
+++ b/campaignresourcecentre/resources/templates/search.html
@@ -203,7 +203,9 @@
         function unCheckSubmitForm(elem) {
             const checkbox = document.getElementById(elem.getAttribute("value").toLowerCase());
             if(checkbox) {
+                const next = document.activeElement.nextElementSibling;
                 checkbox.click();
+                next.focus();
             } else {
                 //uncheck the filter item
                 const select = document.getElementById(elem.getAttribute("parent"));


### PR DESCRIPTION
Ensure the filters above the search results are accessible via keyboard.
Change filter to button to enable keyboard access.
Make the search results change on clicking the entire button not just the X so that it can be used by keyboard users and the target is large enough to click e.g. for mobile phone users.
Ensure the focus goes to the next element when the filter is clicked to remove it.
Jira ticket: CV-688