### PR TITLE
fix aria labels for header image and download buttons

### DIFF
--- a/campaignresourcecentre/core/templates/base_page.html
+++ b/campaignresourcecentre/core/templates/base_page.html
@@ -80,7 +80,7 @@
     <header class="nhsuk-header" role="banner">
   <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo">
-      <a class="nhsuk-header__link" href="/" aria-label="Public Health England, homepage">
+      <a class="nhsuk-header__link" href="/" aria-label="Campaigns Resources homepage - Department of Health and Social Care">
         {% include "molecules/header/dhsc-logo.html" %}
       </a>
     </div>

--- a/campaignresourcecentre/resources/templates/resource_page.html
+++ b/campaignresourcecentre/resources/templates/resource_page.html
@@ -108,7 +108,7 @@
                                         {% if resource.can_download and resource.document %}
                                             {% if resource.permission_to_download %}
                                                 <p>
-                                                    <a class="govuk-button secondary-button" href="{{ resource.document.url }}" aria-describedby="{{ resource.title|slugify }}" aria-label="Download {{ resource.title }}">Download this resource </a>
+                                                    <a class="govuk-button secondary-button" href="{{ resource.document.url }}" aria-describedby="{{ resource.title|slugify }}" >Download this resource </a>
                                                     <span class="file-info">{{ resource.document.file_extension|upper }}, </span>
                                                     <span class="file-info">{{ resource.document.get_file_size|filesizeformat }}</span>
                                                 </p>


### PR DESCRIPTION
Change the header aria-label to represent the new header branding correctly
remove the aria-label from the download resource button - as it does not match the text provided in the link