### PR TITLE
Proceed to checkout when errors

### DIFF
--- a/campaignresourcecentre/baskets/templates/view_basket.html
+++ b/campaignresourcecentre/baskets/templates/view_basket.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="resource-order-error-summary" class="govuk-width-container govuk-!-display-none">
+    <div id="resource-order-error-summary" class="govuk-width-container govuk-!-display-none" tabindex="-1">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
@@ -88,7 +88,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 {% if items %}
-                        <p><a href="/orders/address/edit/" class="govuk-button primary-button">Proceed to checkout</a></p>
+                        <p><a href="/orders/address/edit/" class="govuk-button primary-button" id="proceed-to-checkout">Proceed to checkout</a></p>
                 {% endif %}
             </div>
         </div>
@@ -98,4 +98,31 @@
         {% include "static/form_validation.html" %}
         {% include "static/render_basket.html" %}
     {% endblock %}
+    <script>
+        const checkout = document.getElementById("proceed-to-checkout");
+        checkout.addEventListener("click", proceedCheckout);
+
+
+        /**
+         * Check if there are errors before proceeding to checkout.
+         * Prevent the 'Proceed to checkout' link working if there are.
+         * Move the focus to the errors list.
+         */
+        function proceedCheckout(e) {
+            const errorsClass = document.getElementsByClassName("govuk-error-message");
+            const valid = document.getElementsByClassName("govuk-error-message govuk-!-display-none");
+            const errorSummary = document.getElementById("resource-order-error-summary");
+            // Check if the total items in the basket with a potential error message is different from items which have valid values.
+            if(errorsClass.length !== valid.length) {
+                // Prevent the link from working.
+                e.preventDefault();
+                // Prevent the events script from running so the page does not reload.
+                e.stopImmediatePropagation();
+                // Move the focus to the error list.
+                checkout.blur();
+                errorSummary.focus();
+            }
+         }
+
+    </script>
 {% endblock %}


### PR DESCRIPTION
The user now cannot proceed to checkout if there are errors in the basket.
On pressing the 'Proceed to checkout' link the focus will move to the errors list.
