### PR TITLE
Fix error on double click Remove from basket

### DIFF
--- a/campaignresourcecentre/baskets/basket.py
+++ b/campaignresourcecentre/baskets/basket.py
@@ -32,8 +32,6 @@ class Basket:
         if item_id in self.basket:
             del self.basket[item_id]
             self._update_session_basket()
-        else:
-            raise ItemNotInBasketError("Item is not added to basket!")
 
     def change_item_quantity(self, item_id, quantity):
         item = self.basket.get(item_id)


### PR DESCRIPTION
Prevent an error occurring when a user double clicks on 'Remove from basket'. The item is removed by the first click, if the user double clicks the item is no longer there in the basket which was generating an error. Changed so that nothing happens if the item is not in the basket.
CV-837