### PR TITLE
Move error focus baskets

### DIFF
--- a/campaignresourcecentre/core/templates/static/form_action.html
+++ b/campaignresourcecentre/core/templates/static/form_action.html
@@ -9,12 +9,10 @@
         const resourceForm = document.forms[id];
         // Add an item.
         addItem(resourceForm);
-        errorFocus();
         return false;
     }
 
     /**
-     * Create a delay to allow the error list to load.
      * Move the focus to the error list if there are errors.
      * Remove the focus from the form.
      * Add the focus class to the error list.
@@ -22,17 +20,15 @@
      */
     function errorFocus() {
         const errorSummary = document.getElementById('resource-order-error-summary');
-        setTimeout(() => {
-            if(errorSummary.children.length > 0) {
-                document.activeElement.blur();
-                errorSummary.scrollIntoView();
-                errorSummary.focus();
-                errorSummary.classList.add('error-focus');
-                errorSummary.onblur = function()  {
-                    errorSummary.classList.remove('error-focus');
-                }
+        if(errorSummary.children.length > 0) {
+            document.activeElement.blur();
+            errorSummary.scrollIntoView();
+            errorSummary.focus();
+            errorSummary.classList.add('error-focus');
+            errorSummary.onblur = function()  {
+                errorSummary.classList.remove('error-focus');
             }
-        }, "1000");
+        }
     }
 
 </script>

--- a/campaignresourcecentre/core/templates/static/render_basket.html
+++ b/campaignresourcecentre/core/templates/static/render_basket.html
@@ -34,6 +34,8 @@
                         if (this.readyState == 4){
                             if(this.status == 200) {
                                 basketErrors.innerHTML = this.response;
+                                // Move the focus to errors if there are any.
+                                errorFocus();
                             }
                         }
                     }

--- a/campaignresourcecentre/core/templates/static/render_resource_basket.html
+++ b/campaignresourcecentre/core/templates/static/render_resource_basket.html
@@ -42,6 +42,8 @@
                         if (this.readyState == 4){
                             if(this.status == 200) {
                                 basketErrors.innerHTML = this.response;
+                                // Move the focus to errors if there are any.
+                                errorFocus();
                             }
                         }
                     }


### PR DESCRIPTION
The focus was not moving to the error list on the baskets when the error occurred for the first time as the errors list did not always exist when the code was executed. The code to move focus to the error list now runs within the XMLHttpRequest after the data is passed to the template.

Ticket: CV-771