### PR TITLE
Consolidate recent changes adding abusive tests

### DIFF
--- a/FrontEndTests/feature/CRC_Abuse.feature
+++ b/FrontEndTests/feature/CRC_Abuse.feature
@@ -1,0 +1,19 @@
+#noinspection CucumberUndefinedStep
+@Abuse
+Feature: Abusive use of CRCV3 endpoints
+
+  @CRCAbuse-001
+  Scenario: Attempt to abuse the password reset page
+    Given I attempted password reset with a bad user token
+    Given I attempted password reset with a missing user token
+
+  @CRCAbuse-002
+  Scenario: open CRCV3 site and login with email and password
+    Given I loaded CRCV3 site to load the home page
+    When  I click on Sign in button Sign in page loaded with Email_address and and password
+    Then I enter your login details
+    Then I sign in
+    Then I navigate to Guide to Bottle Feeding page
+    Then I attempt to submit an invalid SKU
+    Then I attempt to submit an invalid resource id
+    Then I attempt to submit an valid resource id not matching its SKU

--- a/FrontEndTests/pages/CRCV3_Abuse_Page.py
+++ b/FrontEndTests/pages/CRCV3_Abuse_Page.py
@@ -1,0 +1,21 @@
+from uitestcore.page import BasePage
+from uitestcore.page_element import PageElement
+from selenium.webdriver.common.by import By
+
+
+class CRCV3AbusePage(BasePage):
+
+    heading_1 = PageElement(By.XPATH, "//h1")
+
+    def all_text(self, pe):
+        return "".join(self.interrogate.get_list_of_texts(pe))
+
+    def open_page(self, url):
+        self.interact.open_url(url)
+        self.wait.for_page_to_load()
+
+    def showing_400(self):
+        self.wait.for_page_to_load()
+        assert (
+            self.interrogate.get_text(self.heading_1) == "Incorrect input"
+        ), "400 page not found"

--- a/FrontEndTests/steps/CRCV3_Abuse_Steps.py
+++ b/FrontEndTests/steps/CRCV3_Abuse_Steps.py
@@ -1,0 +1,120 @@
+import os
+import csv
+
+from behave import Step
+from hamcrest import *
+
+from AcceptanceTests.common.common_test_methods import *
+from uitestcore.page_element import PageElement
+
+from pages.CRCV3_Abuse_Page import CRCV3AbusePage
+
+
+@Step("I attempted password reset with a bad user token")
+def bad_reset_1(context):
+    context.page = CRCV3AbusePage(context.browser, context.logger)
+    context.page.open_page(context.url + "/password-set?q=xxx")
+    context.page.showing_400()
+
+
+@Step("I attempted password reset with a missing user token")
+def bad_reset_2(context):
+    context.page = CRCV3AbusePage(context.browser, context.logger)
+    context.page.open_page(context.url + "/password-set")
+    context.page.showing_400()
+
+
+@Step("I navigate to Guide to Bottle Feeding page")
+# This and dependent steps rely on the existence of a Bottle Feeding Leaflet resource page
+def add_to_basket(context):
+    context.page = CRCV3AbusePage(context.browser, context.logger)
+    context.page.open_page(
+        context.url + "/campaigns/start4life/bottle-feeding-leaflet/"
+    )
+
+
+# It's remarkably difficult to programmatically set Firefox in particular to operate without
+# javascript. However because CRCv3 updates page fragments using JS when available, the result from
+# abusive requests can be a full HTML error page rendered as a replacement for a page fragment. This
+# makes detecting error pages by their content impracticable.
+
+# Therefore for that kind of abuse we construct an abusive request with JS/XMLHTTP and confirm
+# that the return status is 400 as it should be
+
+# Execute the following with one parameter, a query selector to identify a completed
+# HTML form to be submitted. The return value delivered through the implicit second callback
+# parameter is the status code of the result of the form submission.
+
+SUBMIT_AUTOMATICALLY_SCRIPT = """
+const form = document.querySelector (arguments[0]);
+const callback = arguments[arguments.length-1];
+function sendData() {
+    const xhr = new XMLHttpRequest();
+
+    // Make a FormData from the form
+    const fd = new FormData(form);
+
+    // Define what happens on successful data submission
+    xhr.addEventListener("load", (event) => {
+        callback (event.target.status);
+    });
+
+    // Define what happens in case of error
+    xhr.addEventListener("error", (event) => {
+        callback(999);
+    });
+
+    // Set up our request
+    xhr.open("POST", form.action);
+
+    // The data sent is what the user provided in the form
+    xhr.send(fd);
+}
+sendData ();
+"""
+
+
+@Step("I attempt to submit an invalid SKU")
+def bad_sku(context):
+    sku_input = context.page.driver.find_element(By.XPATH, "//input[@name='sku']")
+    # Set input to a value we can't enter with the UI
+    context.page.driver.execute_script("arguments[0].value='xxx';", sku_input)
+    context.page.driver.find_element(
+        By.XPATH, "//input[@name='order_quantity']"
+    ).send_keys("1")
+    result = context.page.driver.execute_async_script(
+        SUBMIT_AUTOMATICALLY_SCRIPT, "form[data-title='Guide to bottle feeding']"
+    )
+    assert result == 400, "Page returned %s not 400" % (result,)
+
+
+@Step("I attempt to submit an invalid resource id")
+def bad_resource_id(context):
+    rpi_input = context.page.driver.find_element(
+        By.XPATH, "//input[@name='resource_page_id']"
+    )
+    # Set input to a value we can't enter with the UI
+    context.page.driver.execute_script("arguments[0].value='xxx';", rpi_input)
+    context.page.driver.find_element(
+        By.XPATH, "//input[@name='order_quantity']"
+    ).send_keys("1")
+    result = context.page.driver.execute_async_script(
+        SUBMIT_AUTOMATICALLY_SCRIPT, "form[data-title='Guide to bottle feeding']"
+    )
+    assert result == 400, "Page returned %s not 400" % (result,)
+
+
+@Step("I attempt to submit an valid resource id not matching its SKU")
+def bad_resource_id(context):
+    rpi_input = context.page.driver.find_element(
+        By.XPATH, "//input[@name='resource_page_id']"
+    )
+    # Set input to a value we can't enter with the UI
+    context.page.driver.execute_script("arguments[0].value='255';", rpi_input)
+    context.page.driver.find_element(
+        By.XPATH, "//input[@name='order_quantity']"
+    ).send_keys("1")
+    result = context.page.driver.execute_async_script(
+        SUBMIT_AUTOMATICALLY_SCRIPT, "form[data-title='Guide to bottle feeding']"
+    )
+    assert result == 400, "Page returned %s not 400" % (result,)

--- a/README.md
+++ b/README.md
@@ -393,6 +393,10 @@ Then access the pipeline variables:
 
 and change if ever required. The FRONTEND_TEST_CONTAINER_IMAGE_TAG is configured similarly.
 
+One very useful pipeline parameter is TAGS as mentioned above. This supplies the name of a Behave <https://behave.readthedocs.io/en/stable/index.html> tag to select tests to be run. By default the tag is Smoke, selecting basic tests of CRCv3 functions. Two other useful values are:
+- All - run all tests
+- Abuse - run abuse tests (tests actions that a malicious actor might take outside the UI)
+
 ### Running front end tests locally
 
 These remarks assume that your local development environment is a dev container.

--- a/campaignresourcecentre/baskets/views.py
+++ b/campaignresourcecentre/baskets/views.py
@@ -51,7 +51,7 @@ def _add_item(request):
         return item
     except Exception as e:
         logger.error("Failed to find resource item: %s", e)
-        raise SuspiciousOperation
+        raise SuspiciousOperation("No such item in basket")
 
 
 @paragon_user_logged_in
@@ -98,7 +98,7 @@ def _change_item_quantity(request):
         return basket.change_item_quantity(item_id, payload.get("order_quantity"))
     except Exception as e:
         logger.error("Change item quantity error. Payload: %s", payload)
-    raise SuspiciousOperation
+    raise SuspiciousOperation("Failed to change quantity")
 
 
 @paragon_user_logged_in
@@ -118,7 +118,7 @@ def render_basket_errors(request):
             id = int(r)
             items = basket.get_resource_page_items(id).items()
         except ValueError:
-            raise SuspiciousOperation
+            raise SuspiciousOperation("Invalid quantity")
     else:
         items = basket.get_all_items().items()
 
@@ -148,6 +148,6 @@ def remove_item(request):
         basket.remove_item(item_id)
     except Exception as e:
         logger.error("Remove item error. Payload: %s", payload)
-        raise SuspiciousOperation
+        raise SuspiciousOperation("Can't remove item")
 
     return redirect("/baskets/view_basket/")

--- a/campaignresourcecentre/core/middleware/crccachingmiddleware.py
+++ b/campaignresourcecentre/core/middleware/crccachingmiddleware.py
@@ -10,7 +10,6 @@
 
 import logging
 
-from django.http import HttpResponseServerError
 from django.middleware.cache import UpdateCacheMiddleware, FetchFromCacheMiddleware
 from django.utils.cache import (
     patch_vary_headers,
@@ -66,7 +65,7 @@ class CRCUpdateCacheMiddleware(UpdateCacheMiddleware):
                 logger.info(
                     "Potentially cachable page %s set cookies %s",
                     path,
-                    sorted(response.cookies.items()),
+                    sorted(response.cookies.keys()),
                 )
                 add_never_cache_headers(response)
             else:
@@ -94,7 +93,7 @@ class CRCFetchFromCacheMiddleware(FetchFromCacheMiddleware):
                     path,
                     sorted(response.cookies.items()),
                 )
-                return HttpResponseServerError()
+                raise Exception("Cached page set cookies")
             # Don't serve any cached page to a Django/Wagtail user
             if hasattr(request, "user") and request.user.is_authenticated:
                 logger.debug(

--- a/campaignresourcecentre/orders/views.py
+++ b/campaignresourcecentre/orders/views.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import SuspiciousOperation
 from django.db import transaction
-from django.views.decorators.http import require_http_methods
 from django.shortcuts import redirect, render
+from django.views.decorators.http import require_http_methods
 
 # Beware this exception is specific to Postgres. It presents as a Postgres error, not an integrity error
 from psycopg2.errors import UniqueViolation
@@ -85,7 +85,7 @@ def place_order(request):
     items = basket.get_all_items().values()
     # Front-end shouldn't ever route to this entry with an empty basket
     if len(items) == 0:
-        raise SuspiciousOperation
+        raise SuspiciousOperation("Empty basket")
     with transaction.atomic():
         try:
             osn = OrderSequenceNumber.objects.get(date=datetime.date.today())

--- a/campaignresourcecentre/paragon_users/decorators.py
+++ b/campaignresourcecentre/paragon_users/decorators.py
@@ -1,7 +1,6 @@
 from functools import wraps
 from logging import getLogger
 
-from django.http import HttpResponseServerError
 from django.shortcuts import redirect, render
 from campaignresourcecentre.paragon.client import Client
 from campaignresourcecentre.paragon.exceptions import ParagonClientError
@@ -43,7 +42,7 @@ def verified_user(
                             )
                         except ParagonClientError as PCE:
                             logger.error("Paragon error: %s" % PCE)
-                            return HTTPResponseServerError()
+                            raise Exception("User lookup failed")
                         request.session["Verified"] = user.get(
                             "ProductRegistrationVar2"
                         )

--- a/campaignresourcecentre/utils/views.py
+++ b/campaignresourcecentre/utils/views.py
@@ -1,26 +1,27 @@
+from logging import getLogger
 from urllib.parse import quote
 
 from django.http import (
     HttpResponseBadRequest,
     HttpResponseForbidden,
-    HttpResponseNotFound,
-    HttpResponseServerError,
 )
 from django.template import loader
 from django.views import defaults
 
+logger = getLogger("__name__")
 
-def bad_request(request, message=None, template_name="errors/400.html"):
+
+def bad_request(request, exception=None, template_name="errors/400.html"):
+    exception = exception or ""
     # Should be just the below line and this should be called implicitly by
     # raising SuspiciousOperation or BadRequest
     # 'return defaults.bad_request(request, template_name)'
-    # Django seems to insist on treating these exceptions as ServerError whatever
-    # Instead we have to cook the response ourselves based on
+    # Django seems unable to find/use our 400 template and reverts to its default
+    # So we have to cook the response ourselves based on
     # https://github.com/django/django/blob/main/django/views/defaults.py
-    # and call this view function explicitly when we need to return a 400 response
     context = {
         "request_path": quote(request.path),
-        "message": message,
+        "message": str(exception),
     }
     template = loader.get_template(template_name)
     body = template.render(context, request)

--- a/execute-frontendtests.sh
+++ b/execute-frontendtests.sh
@@ -26,6 +26,7 @@ echo "Test ${BASE_URL:?No deployment URL specified (BASE_URL)} in $WORK with tag
 
 cp -r FrontEndTests $WORK
 mkdir $WORK/work
+OLD_PWD=$PWD
 cd $WORK/work
 
 echo "### Running docker container image ${IMAGE_TAG:?No image tag specified (IMAGE_TAG)}"
@@ -54,5 +55,6 @@ docker run \
 PASSED=$?
 echo "Status of tests: $PASSED"
 
+cd $OLD_PWD
 
 exit $PASSED


### PR DESCRIPTION
These changes remedy the presentation of some 4xx errors and introduce new front-end tests simulating abusive attacks on the application, i.e. those that require interventions by a malicious actor outside the UI.

The execute-frontendtests.sh file was modified so that it restores the current working directory and can be run multiple times in succession.