### PR TITLE
Header link

### DIFF
--- a/campaignresourcecentre/static_src/sass/layout/_header.scss
+++ b/campaignresourcecentre/static_src/sass/layout/_header.scss
@@ -15,6 +15,8 @@
             height: auto;
             width: auto;
             display: inline-block;
+            position: relative;
+            z-index: 999;
 
             svg {
                 width: 340px;


### PR DESCRIPTION
Make the link for the DHSC logo to the homepage clickable regardless of browser width. Previously, it was behind the header content for some browser widths.

CV-975