### PR TITLE
Revert "Bump socket.io-parser from 4.0.4 to 4.0.5 (#178)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12557,19 +12557,6 @@
         "engine.io": "~6.2.0",
         "socket.io-adapter": "~2.4.0",
         "socket.io-parser": "~4.0.4"
-      },
-      "dependencies": {
-        "socket.io-parser": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
-          "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
-          "dev": true,
-          "requires": {
-            "@types/component-emitter": "^1.2.10",
-            "component-emitter": "~1.3.0",
-            "debug": "~4.3.1"
-          }
-        }
       }
     },
     "socket.io-adapter": {
@@ -12588,15 +12575,28 @@
         "debug": "~4.3.2",
         "engine.io-client": "~6.2.1",
         "socket.io-parser": "~4.2.0"
+      },
+      "dependencies": {
+        "socket.io-parser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
+          "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
+          "dev": true,
+          "requires": {
+            "@socket.io/component-emitter": "~3.1.0",
+            "debug": "~4.3.1"
+          }
+        }
       }
     },
     "socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
       "dev": true,
       "requires": {
-        "@socket.io/component-emitter": "~3.1.0",
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
         "debug": "~4.3.1"
       }
     },


### PR DESCRIPTION
This reverts commit 23dfc77704dabc4002aaf8b49e45a1a025155bd7.