### PR TITLE
Change duplicate email text

### DIFF
--- a/campaignresourcecentre/paragon_users/templates/users/signup.html
+++ b/campaignresourcecentre/paragon_users/templates/users/signup.html
@@ -144,6 +144,7 @@
                                         {{ error}}
                                         {% if error == "Account for this email address already exists" %}
                                             <div class="govuk-hint"><a href="/login">Sign in</a> with this email address or register with a different email address</div>
+                                            <div class="govuk-hint">If you're trying to update your details or contact preferences please go to the account area <a href="/account">here</a></div>
                                         {% endif %}
                                     {% endfor %}
                                 </p>


### PR DESCRIPTION
Changes the text for the error message "Email already exists" to add clarification for the new user registration journey. 