### PR TITLE
Support production build in local build

### DIFF
--- a/campaignresourcecentre/apps.py
+++ b/campaignresourcecentre/apps.py
@@ -43,10 +43,11 @@ class CRCV3Config(AppConfig):
                     logger.info("Forcing connection max age to zero for runserver")
                     default_database["CONN_MAX_AGE"] = 0
             # Set plain text gov notify id Django setting here because now we can import it
-            settings.GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID = (
-                GovNotifyNotifications.PLAIN_EMAIL_TEMPLATE_ID
-            )
+
             logger.info(
                 "Email template setting initialised as %s",
-                settings.GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID,
+                GovNotifyNotifications.PLAIN_EMAIL_TEMPLATE_ID,
             )
+        settings.GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID = (
+            GovNotifyNotifications.PLAIN_EMAIL_TEMPLATE_ID
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        BUILD_ENV: dev
+        BUILD_ENV: ${BUILD_ENV}
     init: true
     environment:
       ALLOWED_HOSTS: 127.0.0.1,0.0.0.0,localhost

--- a/docker/bashrc.sh
+++ b/docker/bashrc.sh
@@ -2,9 +2,7 @@
 # Note: gunicorn requires at least two workers to avoid request blocking
 
 alias dj="python manage.py"
+alias djrun="python manage.py runserver 0.0.0.0:8000"
+alias djgun="gunicorn campaignresourcecentre.wsgi:application --reload"
+alias djtest="python manage.py test --settings=campaignresourcecentre.settings.test"
 
-if [ "$BUILD_ENV" = "dev" ]; then
-    alias djrun="python manage.py runserver 0.0.0.0:8000"
-    alias djgun="gunicorn campaignresourcecentre.wsgi:application --reload"
-    alias djtest="python manage.py test --settings=campaignresourcecentre.settings.test"
-fi

--- a/manage.py
+++ b/manage.py
@@ -11,10 +11,13 @@ if __name__ == "__main__":
 
     if settings.DEBUG:
         if os.environ.get("RUN_MAIN") or os.environ.get("WERKZEUG_RUN_MAIN"):
-            import ptvsd
+            try:
+                import ptvsd
 
-            ptvsd.enable_attach(address=("0.0.0.0", 4000))
-            print("Debugger attached on port 4000!")
+                ptvsd.enable_attach(address=("0.0.0.0", 4000))
+                print("Debugger attached on port 4000!")
+            except ImportError:
+                print("Not a dev build, can't attach debugger")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
There was a bug in the previous commit that meant the plain text email setting was not imported in all Django contexts.

Also, testing locally of features that differ between development and production builds was broken, the Docker compose for local runs only supported dev builds. So the fault being addressed by the ticket could not be reproduced locally.