### PR TITLE
Disallow HEAD request to login

### DIFF
--- a/campaignresourcecentre/paragon_users/views.py
+++ b/campaignresourcecentre/paragon_users/views.py
@@ -244,6 +244,7 @@ def get_role(user_email: str, user_job: str):
         return "standard"
 
 
+@require_http_methods(["POST", "GET"])
 @paragon_user_logged_out
 def login(request):
     if request.method == "GET":


### PR DESCRIPTION
Deals with 500 server error if someone accesses login endpoint with a HEAD request, as the logs say they occasionally do.
HEAD requests are rare in modern usage, and rejecting them is our established practice with other endpoints like contact us and password reset.