### PR TITLE
Add hosted OWASP dependency check

### DIFF
--- a/sonarqube.yml
+++ b/sonarqube.yml
@@ -39,22 +39,37 @@ jobs:
         cliProjectName: 'DCT_Campaigns_Resource_Centre'
         cliSources: '.'
         extraProperties: |
-          sonar.exclusions = campaignresourcecentre/**/migrations/*, campaignresourcecentre/dependency-scan-results/dependency-check-report.html, campaignresourcecentre/utils/tests/test_models.py, campaignresourcecentre/paragon/tests.py, campaignresourcecentre/notifications/adapters.py, FrontEndTests/**/*.py
+          sonar.exclusions = campaignresourcecentre/**/migrations/*, campaignresourcecentre/dependency-scan-results/*, campaignresourcecentre/utils/tests/test_models.py, campaignresourcecentre/paragon/tests.py, campaignresourcecentre/notifications/adapters.py, FrontEndTests/**/*.py
           sonar.python.coverage.reportPaths = /home/vsts/work/1/s/docker/coverage.xml
-    - task: dependency-check-build-task@6
-      inputs:
-        projectName: 'dct-campaign-resource-centre'
-        reportsDirectory: '$(System.DefaultWorkingDirectory)/campaignresourcecentre/dependency-scan-results'
-        scanPath: '$(Build.SourcesDirectory)'
-        format: "JUNIT"
-        additionalArguments: --format "HTML"
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(System.DefaultWorkingDirectory)/campaignresourcecentre/dependency-scan-results/*junit.xml'
-        testRunTitle: 'Dependency check'
-        searchFolder: '$(Common.TestResultsDirectory)'
     - task: SonarQubeAnalyze@5
+
+  - job: run_hosted_OWASP_Dependency_Check
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download OWASP artifact
+      inputs:
+        buildType: "specific"
+        project: "nhsuk.utilities"
+        definition: "[schedule]-owasp-dependency-check-update"
+        buildVersionToDownload: "latestFromBranch"
+        branchName: refs/heads/main
+        artifactName: "owasp"
+        targetPath: "$(Pipeline.Workspace)/owasp"
+        allowPartiallySucceededBuilds: true
+    - task: Bash@3
+      displayName: Run OWASP Dependency Check
+      condition: and(succeeded(),eq(variables['DisableOwaspDependencyCheck'],false))
+      inputs:
+        workingDirectory: $(Pipeline.Workspace)/owasp
+        filePath: $(Pipeline.Workspace)/owasp/run_owasp_scanner.sh
+        arguments: '--scan "$(System.DefaultWorkingDirectory)" --failOnCVSS "$(OWASP.Fail.Score)" --project "$(Build.Repository.Name)" --out "$(System.DefaultWorkingDirectory)/dependency-scan-results" --format HTML --format JUNIT --format JSON'
+    - task: PublishTestResults@2
+      displayName: "Publish OWASP dependency check results"
+      condition: and(succeededOrFailed(),eq(variables['DisableOwaspDependencyCheck'],false))
+      inputs:
+        testRunner: JUnit
+        testResultsFiles: $(System.DefaultWorkingDirectory)/dependency-scan-results/dependency-check-junit.xml"
+        testRunTitle: "OWASP Dependency check"
 
   - job: SonarQube_review
     dependsOn: SonarQube_analysis


### PR DESCRIPTION
This is an implementation of the hosted dependency check described at https://nhsd-confluence.digital.nhs.uk/display/NA/Usage+of+hosted+OWASP+Dependency+Check.
This replaces our current dependency check that runs in the SonarQube pipeline of the CRCv3 project.

Some notes re the checker itself and its documentation:

- the  name of the pipeline used in the code snippet to retrieve the artifact `[publish]-owasp-dependency-check` was incorrect: should be `[schedule]-owasp-dependency-check`
- no changes to security principals or authorisations were required, although this is implied by the documentation. This is perhaps project specific, because we have existing arrangements enabling our project source to be hosted on Github, and our front-end test and performance test pipelines to access that repository.
- the test used for comparing severity level seems incorrect. It's not clear why this is failed by the checker:
<img width="868" alt="image" src="https://github.com/nhsuk/dct-campaign-resource-centre/assets/3966534/6dd3f018-7382-4878-b59a-003fc01a6258">

The following changes were made to the CRC build pipeline:
- allowing other projects to access the pipeline
- new variables to enable/disable the dependency check altogether, and if enabled to set a severity threshold

The threshold is currently set to a high value to maintain current behaviour. It can be set lower in an individual run to identify errant dependencies, with the intention of progressively resolving them and adjusting the pipeline value higher. 