### PR TITLE
Correct failing error message

### DIFF
--- a/campaignresourcecentre/search/azure.py
+++ b/campaignresourcecentre/search/azure.py
@@ -447,7 +447,11 @@ class AzureSearchBackend(BaseSearchBackend):
                 if len(resources) == 1:
                     self.delete_search_resource(resources[0])
                 else:
-                    logger.info("Resource to delete not found - url {}".format(url))
+                    logger.info(
+                        "Resource to delete not found or ambiguous - {}".format(
+                            resources
+                        )
+                    )
         else:
             logger.error("Invalid response: {}".format(response.get("search_content")))
 


### PR DESCRIPTION
Correcting problem with not exactly one resource returned when searching for items to delete in update_index

Review database does not have any resources provoking this problem.

https://crc-v3-review-cv-1077-7.nhswebsite-dev.nhs.uk/crc-admin/update_index/

then

https://crc-v3-review-cv-1077-7.nhswebsite-dev.nhs.uk/crc-admin/search_orphans/

demonstrates normal operation, i.e. a clean database. No duplicates on front page:

https://crc-v3-review-cv-1077-7.nhswebsite-dev.nhs.uk/campaigns/