### PR TITLE
Add list_index command to manage search object files

### DIFF
--- a/campaignresourcecentre/azurestore/utils.py
+++ b/campaignresourcecentre/azurestore/utils.py
@@ -89,6 +89,10 @@ class AzureStorage:
     def get_taxonomy_terms(self, taxonomy_id):
         pass
 
+    def list_json_files(self):
+        files = self._storage.listdir(self._storage.azure_container)
+        print("Index files", files)
+
     def add_json_file(self, name, data):
         json_file = ContentFile(json.dumps(data, indent=2).encode())
         self._storage.delete(name)
@@ -103,6 +107,7 @@ class AzureStorage:
         page_type = resource_data["resource"]["objecttype"]
         try:
             index_file_name = self._get_azure_filename(page_type, resource_id)
+            resource_data["index_file_name"] = index_file_name
             index_file = ContentFile(json.dumps(resource_data).encode())
             # Remove any existing search resource blob
             self._storage.delete(index_file_name)

--- a/campaignresourcecentre/core/management/commands/listindex.py
+++ b/campaignresourcecentre/core/management/commands/listindex.py
@@ -1,0 +1,58 @@
+import json
+import logging
+import re
+import requests
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from campaignresourcecentre.azurestore.utils import AzureStorage
+from campaignresourcecentre.search.azure import AzureSearchBackend
+
+logger = logging.getLogger(__name__)
+
+
+def process_files(filenames, url_re, process_file):
+    for filename in sorted(filenames):
+        if url_re is None or url_re.match(filename):
+            process_file(filename)
+
+
+class Command(BaseCommand):
+    def _process_file(self, filename, deleting):
+        filepath = "/asset/%s" % filename
+        if deleting:
+            try:
+                self.storage._storage.delete(filepath)
+                self.stdout.write(f"{filepath} deleted")
+            except Exception as e:
+                self.stdout.write(f"failed to delete {filepath}: {e}")
+        else:
+            self.stdout.write(f"{filepath}")
+
+    def handle(self, *args, **kwargs):
+        self.storage = AzureStorage()
+        self.backend = AzureSearchBackend({})
+        deleting = kwargs.get("delete")
+        try:
+            url_re = re.compile(kwargs["urls"]) if kwargs.get("urls") else None
+            _, filenames = self.storage._storage.listdir("/asset")
+            process_files(
+                filenames,
+                url_re,
+                lambda filename: self._process_file(filename, deleting),
+            )
+        except Exception as e:
+            self.stderr.write(f"Couldn't process filenames: {e}")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            dest="delete",
+            default=False,
+            help="Delete search object files ifrom Azure container",
+        )
+        parser.add_argument(
+            "--urls", dest="urls", help="Use only filenames matching a pattern"
+        )

--- a/campaignresourcecentre/custom_storages/custom_azure.py
+++ b/campaignresourcecentre/custom_storages/custom_azure.py
@@ -310,7 +310,11 @@ class AzureSearchStorage(AzureStorage):
 
     def __init__(self, **settings):
         super().__init__(**settings)
-        logger.info("Using storage domain '%s' for search", self.custom_domain)
+        logger.info(
+            "Using storage container %s in domain %s for search index",
+            self.azure_container,
+            self.custom_domain,
+        )
 
 
 # Based on default_storage in https://github.com/django/django/blob/main/django/core/files/storage.py

--- a/campaignresourcecentre/urls.py
+++ b/campaignresourcecentre/urls.py
@@ -43,6 +43,7 @@ from campaignresourcecentre.standardpages.views import (
     cookie_declaration,
     update_index,
     search_orphans,
+    list_index,
 )
 
 
@@ -57,6 +58,7 @@ private_urlpatterns = [
     path("crc-admin/clear_cache/", clear_cache, name="clear_cache"),
     path("crc-admin/update_index/", update_index, name="update_index"),
     path("crc-admin/search_orphans/", search_orphans, name="search_orphans"),
+    path("crc-admin/list_index/", list_index, name="list_index"),
     path("crc-admin/", include(wagtailadmin_urls)),
     path("crc-admin/pub", publish_pages, name="publish_pages"),
     path("crc-documents/", include(wagtaildocs_urls)),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-# Excluding this file because it is covered by tests but not detected in the coverage tests,
-# because it is a  Django commands executed in a subprocess.
+# Excluding these files because they are covered by tests but not detected in the coverage tests,
+# because they implement Django commands executed in a subprocess.
 # Its methods cannot be straightforwardly mocked because a very complicated
 # sequence of intervening classes and objects must also be mocked
-sonar.coverage.exclusions=campaignresourcecentre/search/azure.py
+sonar.coverage.exclusions=campaignresourcecentre/search/azure.py, campaignresourcecentre/core/management/commands/listindex.py


### PR DESCRIPTION
The new listindex management command complements the searchorphans command. Once orphan objects have been identified their files may be deleted using a similar technique of selecting their filename with a regular expression and then deleting them. Some search orphans are not accessible to the searchorphans command that looks only at search result.
listindex lists all the of files in the search blob container. Basically files that are not recreated by update_index are orphans.