### PR TITLE
Redirect from address if empty basket

### DIFF
--- a/campaignresourcecentre/orders/views.py
+++ b/campaignresourcecentre/orders/views.py
@@ -58,6 +58,7 @@ def summary(request):
 @paragon_user_logged_in
 def delivery_address(request):
     user_token = request.session.get("ParagonUser")
+    no_items = len(request.session.get("BASKET"))
     if request.method == "POST":
         f = DeliveryAddressForm(request.POST)
         paragon_client = Client()
@@ -76,6 +77,9 @@ def delivery_address(request):
     else:
         delivery_address = request.session.get("DELIVERY_ADDRESS")
         f = DeliveryAddressForm(delivery_address)
+        # Redirect the user if there are no items in the basket
+        if no_items == 0:
+            return redirect("/account/orders/")
     return render(request, "delivery_address.html", {"form": f})
 
 


### PR DESCRIPTION
If the user places an order then attempts to click the browser back button several times, they will not be able to access the address form page to edit it, instead they will be redirected to their orders page.

CV-1123