### PR TITLE
[CV-1172] Update cookies list used by CRC

### DIFF
--- a/campaignresourcecentre/standardpages/templates/cookies.html
+++ b/campaignresourcecentre/standardpages/templates/cookies.html
@@ -61,6 +61,26 @@
                                         <td class="govuk-table__cell">When you close the browser</td>
                                     </tr>              
                                     <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">s_cc</td>
+                                        <td class="govuk-table__cell">Used by Adobe Site Catalyst for analytics</td>
+                                        <td class="govuk-table__cell">When you close the browser</td>
+                                    </tr>              
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">s_ppn</td>
+                                        <td class="govuk-table__cell">Used by Adobe Site Catalyst for analytics</td>
+                                        <td class="govuk-table__cell">When you close the browser</td>
+                                    </tr>              
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">s_getNewRepeat</td>
+                                        <td class="govuk-table__cell">Used by Adobe Site Catalyst for analytics</td>
+                                        <td class="govuk-table__cell">When you close the browser</td>
+                                    </tr>              
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">s_sq</td>
+                                        <td class="govuk-table__cell">Used by Adobe Site Catalyst for analytics</td>
+                                        <td class="govuk-table__cell">When you close the browser</td>
+                                    </tr>              
+                                    <tr class="govuk-table__row">
                                         <td class="govuk-table__cell">csrftoken</td>
                                         <td class="govuk-table__cell">Helps keep the site secure by preventing cross-site
                                             request forgery (CSRF) attacks</td>


### PR DESCRIPTION
Updated list of cookies being used by CRC.

Jira Ticket: https://digitaltools.phe.org.uk/browse/CV-1172
