### PR TITLE
Fix leave site dialogue

### DIFF
--- a/campaignresourcecentre/core/templates/static/form_action.html
+++ b/campaignresourcecentre/core/templates/static/form_action.html
@@ -34,7 +34,7 @@
     /**
      * Ensure the error list is in view if the page is refreshed
      */
-    window.addEventListener('beforeunload', (event) => {
+    window.addEventListener('unload', (event) => {
         event.preventDefault();
         errorFocus();
     });


### PR DESCRIPTION
Change `beforeunload` to `unload` to fix leave site dialogue, if the user refreshes the page, the page will still scroll to the error list.