### PR TITLE
fix(CRC): Increasing checkout depth to fix cleanup pipelines

### DIFF
--- a/azure-pipeline-templates/cleanup.yml
+++ b/azure-pipeline-templates/cleanup.yml
@@ -13,6 +13,7 @@ trigger:
 steps:
 - checkout: self
   persistCredentials: true
+  fetchDepth: 0
 
 - task: AzureCLI@2
   inputs:


### PR DESCRIPTION
The review cleanup job works by comparing the list of branches in the git repo with the list of k8s namespaces, if it can't tie up the namespace with the branch then it gets removed.

However by default the Azure Devops task doesn't retrieve the complete list of branches from remote which meant it always deleted any namespace.

Adding fetchDepth: 0 ensures that the complete list of branches is returned and they can persist between cleanup operations.