### PR TITLE
Review/1175 improve dcx error logging

### DIFF
--- a/azure-pipeline-templates/deploy.yml
+++ b/azure-pipeline-templates/deploy.yml
@@ -1,20 +1,4 @@
 steps:
-  - powershell: |
-      $namespace = "$(namespace)"
-      $formattedNamespace = $namespace.ToLower() -replace '[^a-zA-Z0-9-``.]', ''
-      Write-Host $formattedNamespace
-      Write-Host "##vso[task.setvariable variable=namespace;]$formattedNamespace"
-
-      $tag = "$(tag)"
-      $formattedTag = $tag.ToLower() -replace '[^a-zA-Z0-9-``.]', ''
-      Write-Host $formattedTag
-      Write-Host "##vso[task.setvariable variable=tag;]$formattedTag"
-
-      $hostUrl = "$(hostUrl)"
-      $formattedHostUrl = $hostUrl.ToLower() -replace '[^a-zA-Z0-9-``.]', ''
-      Write-Host $formattedHostUrl
-      Write-Host "##vso[task.setvariable variable=hostUrl;]$formattedHostUrl"
-    displayName: Format deployment variables
   - task: AzureKeyVault@1
     inputs:
       azureSubscription: ${{parameters.azureSubscription}}

--- a/campaignresourcecentre/paragon/client.py
+++ b/campaignresourcecentre/paragon/client.py
@@ -48,6 +48,16 @@ class Client:
         elapsed = (finish_time - start_time).total_seconds()
         logger.info("Paragon client %s call took %0.3fs", self.call_method, elapsed)
         if failed:
+            logger.error(
+                json.dumps(
+                    {
+                        "error": "Paragon client timeout exceeded",
+                        "endpoint": self.call_method,
+                        "elapsed": elapsed,
+                        "timeoutLimit": settings.PARAGON_LOGIN_TIMEOUT_SECONDS,
+                    }
+                )
+            )
             raise ParagonClientTimeout
 
     # Revised call - delegates to either mock or real API
@@ -94,6 +104,17 @@ class Client:
             self._call()
 
     def raise_exception(self):
+        logger.error(
+            json.dumps(
+                {
+                    "error": "Paragon client request unsuccessful",
+                    "endpoint": self.call_method,
+                    "response": json.loads(self.response.content),
+                    "status": self.response.status_code,
+                    "elapsed": self.response.elapsed.total_seconds(),
+                }
+            )
+        )
         raise ParagonClientError(json.loads(self.response.content))
 
     def create_account(


### PR DESCRIPTION
When response status code is not 200 for /login and /signup we always throw a ParagonClientError with the response content so it's in this case that we needed to add the logging of the response content.