### PR TITLE
CV-694: update wagtail-reacttaxonomy reference

### DIFF
--- a/poetry/poetry.lock
+++ b/poetry/poetry.lock
@@ -2586,7 +2586,7 @@ develop = false
 type = "git"
 url = "https://github.com/nhsuk/wagtail-reacttaxonomy"
 reference = "wagtail4"
-resolved_reference = "a786f779ca5262803a7b7c145b5d5a729700a9da"
+resolved_reference = "84aea27ebf27958ce53819243cbce464ef0178af"
 
 [[package]]
 name = "webencodings"


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://digitaltools.phe.org.uk/browse/CV-694

## Description

Update "wagtail-reacttaxonomy" version to include removal of "help-critical" from a hidden div
This is the "wagtail-reacttaxonomy" change: https://github.com/nhsuk/wagtail-reacttaxonomy/pull/29
This now means the alert/badge on the taxonomy tab is not permanently displaying (1)

Since diff for poetry.lock won't load, this is the change:
```
[[package]]
name = "wagtail-reacttaxonomy"
version = "0.0.1"
description = "Add React Taxonomy component to a wagtail page and store it as a json in the db"
category = "main"
optional = false
python-versions = "*"
files = []
develop = false

[package.source]
type = "git"
url = "https://github.com/nhsuk/wagtail-reacttaxonomy"
reference = "wagtail4"
# resolved_reference = "a786f779ca5262803a7b7c145b5d5a729700a9da" - Replaced with below
resolved_reference = "84aea27ebf27958ce53819243cbce464ef0178af"
```

This resolved_reference was updated by running the `poetry lock` command

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [X] I have performed a self-review of my own code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have updated the documentation accordingly~~
- [X] Jira ticket has up-to-date ACs and necessary test documentation
