### PR TITLE
[CV-1288] Inject basic auth credentials for staging tests

### DIFF
--- a/aks-deploy-pipelines.yml
+++ b/aks-deploy-pipelines.yml
@@ -36,7 +36,7 @@ parameters:
     displayName: Force Deploy Production
     type: boolean
     default: false
-  - name: deployDr 
+  - name: deployDr
     displayName: Force Deploy DisasterRecovery
     type: boolean
     default: false
@@ -324,6 +324,8 @@ stages:
               kubernetesServiceConnection: 'helm-dct-platforms-aks-stag-uksouth-dct.campaign-resource-centre-v3'
               kubernetesServiceEndPoint: 'helm-dct-platforms-aks-stag-uksouth-dct.campaign-resource-centre-v3'
           - template: azure-pipeline-templates/frontendtest.yml
+            parameters:
+              authorize: STAGING_AUTHORIZATION
   - stage: deployProduction
     displayName: 'Deploy Production'
     condition: or(and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/')), ${{ parameters.deployProduction }})

--- a/azure-pipeline-templates/frontendtest.yml
+++ b/azure-pipeline-templates/frontendtest.yml
@@ -1,3 +1,7 @@
+parameters:
+- name: authorize
+  default: "None"
+
 steps:
   - task: DownloadSecureFile@1
     displayName: 'Download username/password secret file'
@@ -16,4 +20,5 @@ steps:
       IMAGE_TAG: $(imageTag)
       PARALLEL: 4
       SCENARIOS: parallel
+      AUTHORIZE: ${{ parameters.authorize }}
     displayName: 'Run Frontend tests in Docker container'

--- a/execute-frontendtests.sh
+++ b/execute-frontendtests.sh
@@ -16,12 +16,20 @@
 # IMAGE_TAG: Tag for required version of the Front End test image
 # PARALLEL - number of parallel runs to execute (default 1)
 # SCENARIOS - how to run scenarios (sequential/parallel, default sequential)
+# AUTHORIZE - optional env variable name containing basic auth credentials
 
 echo "### IMAGE_TAG: ${IMAGE_TAG:=1.1.1}"
 echo "### PARALLEL: ${PARALLEL:=1}"
 echo "### SCENARIOS: ${SCENARIOS:=sequential}"
 echo "### TIMEOUT: ${TIMEOUT:=3000}s"
-
+echo "### AUTHORIZE: ${AUTHORIZE:=None}"
+if [ "$AUTHORIZE" == "None" ]
+then
+  AUTH_URL=$BASE_URL
+else
+  AUTH_URL="https://${!AUTHORIZE}@${BASE_URL#https://}"
+  echo "Authorization inserted into BASE_URL as $AUTH_URL"
+fi
 # Can't have empty value for TAGS as pipeline parameter so change "all" to "" here
 TAGS=$([ "$TAGS" = "all" ] && echo "" || echo "$TAGS")
 echo "Effective TAGS: '$TAGS'"
@@ -41,23 +49,23 @@ docker build --build-arg IMAGE_TAG=${IMAGE_TAG} -t my-acceptancetests:${IMAGE_TA
 
 printf  'Docker Build completed'
 
-# Wait for the BASE_URL to be available or timeout after one minute
+# Wait for the AUTH_URL to be available or timeout after one minute
 
 for i in {1, 6}
 do
-  curl --output /dev/null -k --head --fail --max-time 10 ${BASE_URL} && break
+  curl --output /dev/null -k --head --fail --max-time 10 ${AUTH_URL} && break
   printf 'Failed to access server, trying again in 10 seconds...\n'
   sleep 10
 done
 printf  'Server seems to be responding - confirm\n'
 # Confirm site now running or fail
-curl --output /dev/null -k --head --fail --max-time 10 ${BASE_URL} || exit 1
+curl --output /dev/null -k --head --fail --max-time 10 ${AUTH_URL} || exit 1
 printf  'Server responded. Running tests now\n'
 
 # get Docker to use host network so it can access localhost:8000 with no fuss
 docker run \
   --network host \
-  --env BASE_URL \
+  --env BASE_URL=$AUTH_URL \
   --env TAGS \
   --env PARALLEL=$PARALLEL \
   --env SCENARIOS=$SCENARIOS \


### PR DESCRIPTION
Staging is behind basic auth and tests are currently failing with a 401. This PR fixes that.

## Jira tickets resolved by this PR

- https://jira.collab.test-and-trace.nhs.uk/browse/CV-1288

## Description

* Adds support for providing the name of an environment variable to the `execute-frontendtests.sh` with basic auth creds
* Add flag to staging deployment tests pointing to new `STAGING_AUTHORIZATION` variable that has been setup on the pipepline

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] Jira ticket has up-to-date ACs and necessary test documentation
