### PR TITLE
[BH-1415] Specify the target type of the metric alert to flex

### DIFF
--- a/terraform/src/common/activeconnections_alert_action_group.tf
+++ b/terraform/src/common/activeconnections_alert_action_group.tf
@@ -12,14 +12,15 @@ resource "azurerm_monitor_action_group" "activeconnections_alert" {
 }
 
 resource "azurerm_monitor_metric_alert" "activeconnections_metric_alert_85" {
-  name                = replace(data.azurerm_resource_group.rg.name, "-rg-", "-activeconnections-metricalert-85-")
-  resource_group_name = data.azurerm_resource_group.rg.name
-  scopes              = [data.azurerm_postgresql_flexible_server.flex.id]
-  description         = "Alert when active connections are greater than or equal to 85."
-  severity            = 2
-  frequency           = "PT1M"
-  window_size         = "PT5M"
-  enabled             = true
+  name                 = replace(data.azurerm_resource_group.rg.name, "-rg-", "-activeconnections-metricalert-85-")
+  resource_group_name  = data.azurerm_resource_group.rg.name
+  scopes               = [data.azurerm_postgresql_flexible_server.flex.id]
+  target_resource_type = "Microsoft.DBforPostgreSQL/flexibleServers"
+  description          = "Alert when active connections are greater than or equal to 85."
+  severity             = 2
+  frequency            = "PT1M"
+  window_size          = "PT5M"
+  enabled              = true
 
   criteria {
     metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
@@ -35,14 +36,15 @@ resource "azurerm_monitor_metric_alert" "activeconnections_metric_alert_85" {
 }
 
 resource "azurerm_monitor_metric_alert" "activeconnections_metric_alert_98" {
-  name                = replace(data.azurerm_resource_group.rg.name, "-rg-", "-activeconnections-metricalert-98-")
-  resource_group_name = data.azurerm_resource_group.rg.name
-  scopes              = [data.azurerm_postgresql_flexible_server.flex.id]
-  description         = "Alert when active connections are greater than or equal to 98."
-  severity            = 0
-  frequency           = "PT1M"
-  window_size         = "PT5M"
-  enabled             = true
+  name                 = replace(data.azurerm_resource_group.rg.name, "-rg-", "-activeconnections-metricalert-98-")
+  resource_group_name  = data.azurerm_resource_group.rg.name
+  scopes               = [data.azurerm_postgresql_flexible_server.flex.id]
+  target_resource_type = "Microsoft.DBforPostgreSQL/flexibleServers"
+  description          = "Alert when active connections are greater than or equal to 98."
+  severity             = 0
+  frequency            = "PT1M"
+  window_size          = "PT5M"
+  enabled              = true
 
   criteria {
     metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://jira.collab.test-and-trace.nhs.uk/browse/BH-1415

## Description

When the initial scope went in, this has been set automatically to `Microsoft.DBforPostgreSQL/servers` but we now must specifically set it to `Microsoft.DBforPostgreSQL/flexibleServers` as the Azure API will 400 Bad Request _sometimes_

Did the update automatically fine on integration, but not on review 🤷 

Now working on review: https://dev.azure.com/nhsuk/dct.campaign-resource-centre-v3/_build/results?buildId=233037&view=logs&j=de9da206-0b48-51ee-3a56-68fca44a7eb4

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] Jira ticket has up-to-date ACs and necessary test documentation
