### PR TITLE
CV-1245: use "field.html" instead of deprecated "field_as_li.html"

### DIFF
--- a/campaignresourcecentre/paragon_users/templates/paragon_users/set_password.html
+++ b/campaignresourcecentre/paragon_users/templates/paragon_users/set_password.html
@@ -31,7 +31,7 @@
                             {% if field.is_hidden %}
                                 {{ field }}
                             {% else %}
-                                {% include "wagtailadmin/shared/field_as_li.html" %}
+                                {% include "wagtailadmin/shared/field.html" %}
                             {% endif %}
                         {% endfor %}
                         <li>


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://jira.collab.test-and-trace.nhs.uk/browse/CV-1245

## Description

Fix needed for Wagtail 6.3 (LTS) upgrade

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
