### PR TITLE
[BH-1696] Move from dctimages to dctcampaignsacrproduks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,14 @@ COPY ./campaignresourcecentre/static_src/ ./campaignresourcecentre/static_src/
 RUN npm run build:prod
 
 
-# We use Debian images because they are considered more stable than the alpine
-# ones becase they use a different C compiler. Debian images also come with
-# all useful packages required for image manipulation out of the box. They
-# however weight a lot, approx. up to 1.5GiB per built image.
 FROM python:3.12-alpine AS backend
 RUN apk update
 RUN apk add curl postgresql-dev bash py3-pip
+
+# Temporary fix for CVE-2025-29087. Remove when Alpine updates it's SQlite version to >= 3.49.1
+RUN apk --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+    add sqlite-libs=3.49.1-r1 sqlite-dev=3.49.1-r1
+
 RUN pip3 install --upgrade pip setuptools
 
 ARG POETRY_HOME=/opt/poetry

--- a/Dockerfile-FrontendTests
+++ b/Dockerfile-FrontendTests
@@ -1,4 +1,4 @@
 ARG IMAGE_TAG
-FROM dctimages.azurecr.io/acceptancetests:${IMAGE_TAG}
+FROM dctcampaignsacrproduks.azurecr.io/acceptancetests:${IMAGE_TAG}
 
 RUN pip install pyotp

--- a/README.md
+++ b/README.md
@@ -147,15 +147,14 @@ After starting the containers as above and running `djrun`, in a new terminal se
 
 ## Front-end testing
 
-Containers are also used for running front-end tests locally since they too have complex dependencies. The tests are all defined in the FrontEndTests folder and get built into a docker image called "acceptancetests" that is stored in the "dctimages.azurecr.io" docker image repository. The version of the tests being run is dictated by the Image Tag the test container is using so make sure you are providing the up to date tag. The construction of the image is detailed here in  a separate GitHub repository:
+Containers are also used for running front-end tests locally since they too have complex dependencies. The tests are all defined in the FrontEndTests folder and get built into a docker image called "acceptancetests" that is stored in the "dctcampaignsacrproduks.azurecr.io" docker image repository. The version of the tests being run is dictated by the Image Tag the test container is using so make sure you are providing the up to date tag. The construction of the image is detailed here in  a separate GitHub repository:
 <https://github.com/nhsuk/dct-frontend-testing-framework>
+
+You must have AcrPull permissions on `dctcampaignsacrproduks` and then setup docker auth with `az acr login --name dctcampaignsacrproduks` to be able to pull the image.
 
 ### Configuration
 
 Configuration related to testing focusses on accessing and specifying the aforementioned "acceptancetests" docker image:
-
-* REPO_USERNAME and REPO_PASSWORD:
-credentials used to access the "dctimages.azurecr.io" docker image repository.
 
 * SECRETS_FILE:
 CSV file containing details of registered users of the CRC site (your email address, your CRC password).
@@ -171,7 +170,7 @@ Used to determine which subset of tests to run (e.g. "@Smoke") - leave empty to 
 The "smoke" tests are automatically run within this build pipeline whenever a review branch is created or modified:
 https://dev.azure.com/nhsuk/dct.campaign-resource-centre-v3/_build?definitionId=1071&_a=summary
 
-From here you can click "Edit", then "Variables" and provide REPO_USERNAME REPO_PASSWORD and IMAGE_TAG (named FRONTEND_TEST_CONTAINER_IMAGE_TAG in the pipeline variables). The other variable secrets file and tags are specified within the pipeline itself.
+From here you can click "Edit", then "Variables" and provide IMAGE_TAG (named FRONTEND_TEST_CONTAINER_IMAGE_TAG in the pipeline variables). The other variable secrets file and tags are specified within the pipeline itself.
 
 The results for the front end tests run in the build pipeline can be found in the "Deploy" stage or the "Deploy Review" job under the "Run Frontend tests in Docker container" task.
 
@@ -187,11 +186,9 @@ An example test_env.sh:
 
 ```
 export BASE_URL=http://localhost:8000
-export REPO_USERNAME=**************
-export REPO_PASSWORD=************************************
 # Note that secrets file requires absolute path because it will be mounted into the container
 export SECRETS_FILE=$PWD/crcv3-1-user.csv
-export IMAGE_TAG=1.0.0
+export IMAGE_TAG=1.1.1
 ```
 
 To run the tests, first get your local CRC instance running in a terminal window:

--- a/azure-pipeline-templates/frontendtest.yml
+++ b/azure-pipeline-templates/frontendtest.yml
@@ -8,6 +8,13 @@ steps:
     name: CSVFile # The name with which to reference the secure file’s path on the agent, like $(CSVFile.secureFilePath)
     inputs:
       secureFile: crcv3-user.csv # A secret file in the pipeline library with a Parkhouse test API username/password value
+  - task: AzureCLI@2
+    displayName: Docker Login (dctcampaignsacrproduks)
+    inputs:
+      azureSubscription: dct-crccms-dev
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: az acr login --name dctcampaignsacrproduks
   - bash: ./execute-frontendtests.sh
     env:
       WORK: $(System.DefaultWorkingDirectory)

--- a/execute-frontendtests.sh
+++ b/execute-frontendtests.sh
@@ -11,8 +11,6 @@
 
 # BASE_URL: URL of the deployment to be tested (https:// + domain)
 # SECRETS_FILE: Path to CSV file containing username/password pair(s)
-# REPO_USERNAME: Username for the Docker repository with the Front End test image
-# REPO_PASSWORD: Password "
 # IMAGE_TAG: Tag for required version of the Front End test image
 # PARALLEL - number of parallel runs to execute (default 1)
 # SCENARIOS - how to run scenarios (sequential/parallel, default sequential)
@@ -43,8 +41,7 @@ cp -r FrontEndTests $WORK
 mkdir $WORK/work
 cd $WORK/work
 
-echo "### Running docker container image ${IMAGE_TAG:?No image tag specified (IMAGE_TAG)}"
-docker login dctimages.azurecr.io -u ${REPO_USERNAME:?No username for the Docker repo (REPO_USERNAME)} -p ${REPO_PASSWORD:?No password for the Docker repo (REPO_PASSWORD)}
+echo "### Building docker container image ${IMAGE_TAG:?No image tag specified (IMAGE_TAG)}"
 docker build --build-arg IMAGE_TAG=${IMAGE_TAG} -t my-acceptancetests:${IMAGE_TAG} -f $REPO_ROOT/Dockerfile-FrontendTests .
 
 printf  'Docker Build completed'


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://jira.collab.test-and-trace.nhs.uk/browse/BH-1696

## Description

`dctimages` will be deleted from `nhsuk-development` soon so we are switching to our ACR in the landing zone subscription.
This PR:
* 🫙 Switches to our `dctcampaignsacrproduks` container registry in the landing zone
* 🛼 Switch from username/password to using managed identity to authenticate to the container registry to remove need for getting the username and password
* 👮‍♂️ Manually bump sqlite to resolve security vulnerability
* 🚮 Remove old comment that is not valid from `Dockerfile`

Working pipeline run with image from new location:
https://dev.azure.com/nhsuk/dct.campaign-resource-centre-v3/_build/results?buildId=264591&view=logs&j=5b8ae161-e616-5f21-d011-2610f8b34bf0&t=6f9616c0-262b-5895-9a13-e18de66cfe39

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] Jira ticket has up-to-date ACs and necessary test documentation
