### PR TITLE
[CV-1321] Add non-prod basic auth and bump network-spoke

### DIFF
--- a/terraform/src/common/env/int-uks.tfvars
+++ b/terraform/src/common/env/int-uks.tfvars
@@ -4,4 +4,5 @@ location       = "uks"
 resource_group = "dct-crccms-rg-int-uks"
 
 deploy_container_apps = true
+username              = "nhsuk"
 network_address_space = "10.5.8.0/22"

--- a/terraform/src/common/env/stag-uks.tfvars
+++ b/terraform/src/common/env/stag-uks.tfvars
@@ -4,4 +4,5 @@ location       = "uks"
 resource_group = "dct-crccms-rg-stag-uks"
 
 deploy_container_apps = false
+username              = "nhsuk"
 network_address_space = "10.8.8.0/22"

--- a/terraform/src/common/network.tf
+++ b/terraform/src/common/network.tf
@@ -1,7 +1,7 @@
 resource "random_uuid" "akamai_guid" {}
 
 module "network_spoke" {
-  source = "git::https://github.com/nhsuk/nhsuk.platform.terraform-modules.network-spoke?ref=0.0.7"
+  source = "git::https://github.com/nhsuk/nhsuk.platform.terraform-modules.network-spoke?ref=a2585314f02cb691b2f6e4f7eecefa8724e63b49"
 
   count = var.deploy_container_apps ? 1 : 0
 


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1321

## Description

We want non-prod environments to be behind basic auth. This PR:
* 🔐 adds username for int and stag (password hash is a pipeline secret)
* 🐞 fix networking peering name collision in network spoke
  
## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
