### PR TITLE
[CV-1321] Bump module to fix provider version constraint

### DIFF
--- a/terraform/src/common/container_app_environment.tf
+++ b/terraform/src/common/container_app_environment.tf
@@ -1,5 +1,5 @@
 module "container_app_env" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.container-app-env?ref=1.0.1"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.container-app-env?ref=1.0.2"
 
   count = var.deploy_container_apps ? 1 : 0
 


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1321

## Description

Bump module to fix provider version constraint as current state is already saved at a higher version

```
│ Error: Resource instance managed by newer provider version
│ 
│ The current state of
│ module.database[0].azurerm_postgresql_flexible_server_virtual_endpoint.database[0]
│ was created by a newer provider version than is currently selected. Upgrade
│ the azurerm provider to work with this state.
```

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
