### PR TITLE
[CV-1326] Add AKS as Front Door origin

### DIFF
--- a/terraform/src/common/container_apps.tf
+++ b/terraform/src/common/container_apps.tf
@@ -1,5 +1,5 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.0"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.1"
 
   # dev container apps get deployed separately to allow for many transient environments
   count = var.deploy_container_apps && var.env != "dev" ? 1 : 0

--- a/terraform/src/common/container_apps.tf
+++ b/terraform/src/common/container_apps.tf
@@ -1,5 +1,5 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.3.0"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.0"
 
   # dev container apps get deployed separately to allow for many transient environments
   count = var.deploy_container_apps && var.env != "dev" ? 1 : 0
@@ -25,4 +25,5 @@ module "aca_wagtail" {
   init_secrets                      = local.init_secrets
   app_secrets                       = local.app_secrets
   alerts_action_group_id            = module.container_app_env[0].alerts_action_group_id
+  aks_origin                        = var.aks_origin
 }

--- a/terraform/src/common/env/int-uks.tfvars
+++ b/terraform/src/common/env/int-uks.tfvars
@@ -6,3 +6,8 @@ resource_group = "dct-crccms-rg-int-uks"
 deploy_container_apps = true
 username              = "nhsuk"
 network_address_space = "10.5.8.0/22"
+
+aks_origin = {
+  firewall_ip_address = "20.49.224.251"
+  origin_host_header  = "crc-v3.nhswebsite-dev.nhs.uk"
+}

--- a/terraform/src/common/env/prod-uks.tfvars
+++ b/terraform/src/common/env/prod-uks.tfvars
@@ -5,3 +5,8 @@ resource_group = "dct-crccms-rg-prod-uks"
 
 deploy_container_apps = false
 network_address_space = "10.12.8.0/22"
+
+aks_origin = {
+  firewall_ip_address = "51.11.24.240"
+  origin_host_header  = "campaignresources.dhsc.gov.uk"
+}

--- a/terraform/src/common/env/stag-uks.tfvars
+++ b/terraform/src/common/env/stag-uks.tfvars
@@ -8,3 +8,8 @@ username              = "nhsuk"
 crc_cms_version       = "1.13.0" # initial version to deploy
 
 network_address_space = "10.8.8.0/22"
+
+aks_origin = {
+  firewall_ip_address = "20.49.242.14"
+  origin_host_header  = "staging.campaignresources.dhsc.gov.uk"
+}

--- a/terraform/src/common/variables.tf
+++ b/terraform/src/common/variables.tf
@@ -64,3 +64,12 @@ variable "network_address_space" {
     error_message = "Must be valid IPv4 CIDR."
   }
 }
+
+variable "aks_origin" {
+  type = object({
+    firewall_ip_address = string
+    origin_host_header  = string
+  })
+  description = "Optional AKS origin on the Front Door origin group to allow for migration"
+  default     = null
+}

--- a/terraform/src/review/main.tf
+++ b/terraform/src/review/main.tf
@@ -1,5 +1,5 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.3.0"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.0"
 
   environment                  = local.environment
   org                          = local.org

--- a/terraform/src/review/main.tf
+++ b/terraform/src/review/main.tf
@@ -1,5 +1,5 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.0"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=0.4.1"
 
   environment                  = local.environment
   org                          = local.org


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1326

## Description

We are migrating to Azure Container Apps. We want to be able to flip traffic over from AKS to ACA ourselves through scripting/pipelines. This PR:

⬆️ bumps wagtail apps module to version that supports AKS origin
📋 configures the AKS firewall for each environment

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
