### PR TITLE
[CV-1341] Replace hand-crafted JSON with `dumps` to correctly escape path segments

### DIFF
--- a/campaignresourcecentre/utils/templatetags/adobe_analytics.py
+++ b/campaignresourcecentre/utils/templatetags/adobe_analytics.py
@@ -1,5 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
+from json import dumps
 
 register = template.Library()
 """
@@ -29,36 +30,20 @@ def adobe_analytics(page_url):
         sub_category_3 = url_list[3] if len(url_list) > 3 else ""
         sub_category_4 = url_list[4] if len(url_list) > 4 else ""
 
-        return """{
-            "primaryCategory": "%s",
-            "subCategory1":"%s",
-            "subCategory2":"%s",
-            "subCategory3":"%s",
-            "subCategory4":"%s"
-            }""" % (
-            primary_category,
-            sub_category_1,
-            sub_category_2,
-            sub_category_3,
-            sub_category_4,
-        )
+        return {
+            "primaryCategory": primary_category,
+            "subCategory1": sub_category_1,
+            "subCategory2": sub_category_2,
+            "subCategory3": sub_category_3,
+            "subCategory4": sub_category_4,
+        }
 
     def form_adobe_js(url_list):
         categories = get_categories(url_list)
         page_name = get_page_name(url_list)
-        adobe_js = """window.digitalData=
-            {"page": {
-                "pageInfo": {
-                    "pageName": "%s"
-               },
-                "category":
-                    %s
-                },
-               };
-            """ % (
-            page_name,
-            categories,
-        )
+        data = {"page": {"pageInfo": {"pageName": page_name}, "category": categories}}
+
+        adobe_js = "window.digitalData= %s;" % dumps(data)
         return mark_safe(adobe_js)
 
     return form_adobe_js(url_list)

--- a/campaignresourcecentre/utils/tests/templatetags/test_adobe_analytics.py
+++ b/campaignresourcecentre/utils/tests/templatetags/test_adobe_analytics.py
@@ -1,0 +1,152 @@
+from django.test import SimpleTestCase
+
+from campaignresourcecentre.utils.templatetags import adobe_analytics
+
+
+def create_categories(primary, one, two, three, four):
+    return (
+        """{"primaryCategory": "%s", "subCategory1": "%s", "subCategory2": "%s", "subCategory3": "%s", "subCategory4": "%s"}"""
+        % (
+            primary,
+            one,
+            two,
+            three,
+            four,
+        )
+    )
+
+
+class AdobeAnalyticsTestCase(SimpleTestCase):
+    """
+    Test adobe_analytics templatetags
+    """
+
+    maxDiff = None
+
+    digital_data = """window.digitalData= {"page": {"pageInfo": {"pageName": "%s"}, "category": %s}};"""
+
+    def test_adobe_analytics_returns_output_for_page_with_no_path_segment(self):
+        """
+        Return fully formed digitalData object when path contains no segments
+        """
+
+        path = ""
+        categories = create_categories(path, "", "", "", "")
+        expected = self.digital_data % ("nhs:phe:campaigns:home", categories)
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_output_for_page_with_one_path_segment(self):
+        """
+        Return fully formed digitalData object when path contains one segment
+        """
+
+        path = "conditions"
+        categories = create_categories(path, "", "", "", "")
+        expected = self.digital_data % ("nhs:phe:campaigns:%s" % path, categories)
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_output_for_page_with_two_path_segments(self):
+        """
+        Return fully formed digitalData object when path contains two segments
+        """
+
+        path = "conditions/treatments"
+        path_segments = path.split("/")
+        categories = create_categories(path_segments[0], path_segments[1], "", "", "")
+        expected = self.digital_data % (
+            "nhs:phe:campaigns:%s" % ":".join(path_segments),
+            categories,
+        )
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_output_for_page_with_three_path_segments(self):
+        """
+        Return fully formed digitalData object when path contains three segments
+        """
+
+        path = "conditions/treatments/symptoms"
+        path_segments = path.split("/")
+        categories = create_categories(
+            path_segments[0], path_segments[1], path_segments[2], "", ""
+        )
+        expected = self.digital_data % (
+            "nhs:phe:campaigns:%s" % ":".join(path_segments),
+            categories,
+        )
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_output_for_page_with_four_path_segments(self):
+        """
+        Return fully formed digitalData object when path contains four segments
+        """
+
+        path = "conditions/treatments/symptoms/medicines"
+        path_segments = path.split("/")
+        categories = create_categories(
+            path_segments[0], path_segments[1], path_segments[2], path_segments[3], ""
+        )
+        expected = self.digital_data % (
+            "nhs:phe:campaigns:%s" % ":".join(path_segments),
+            categories,
+        )
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_output_for_page_with_more_than_four_path_segments(
+        self,
+    ):
+        """
+        Return fully formed digitalData object when path contains more than four segments
+        """
+
+        path = "conditions/treatments/symptoms/medicines/more/stuff"
+        path_segments = path.split("/")
+        categories = create_categories(
+            path_segments[0],
+            path_segments[1],
+            path_segments[2],
+            path_segments[3],
+            path_segments[4],
+        )
+        expected = self.digital_data % (
+            "nhs:phe:campaigns:%s" % ":".join(path_segments),
+            categories,
+        )
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)
+
+    def test_adobe_analytics_returns_escaped_charaters_in_path_segments(
+        self,
+    ):
+        """
+        Return fully formed digitalData object when path contains characters that need escaping
+        """
+
+        path = 'conditions"/treatments"/symptoms"/medicines"/more"/stuff"'
+        categories = create_categories(
+            'conditions\\"', 'treatments\\"', 'symptoms\\"', 'medicines\\"', 'more\\"'
+        )
+        expected = self.digital_data % (
+            'nhs:phe:campaigns:conditions\\":treatments\\":symptoms\\":medicines\\":more\\":stuff\\"',
+            categories,
+        )
+
+        output = adobe_analytics.adobe_analytics(path)
+
+        self.assertHTMLEqual(output, expected)


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1341

## Description

Hand-crafted creation of the Adobe JS object without correctly escaping user input leaves a vulnerability. This PR:
* 👮 replaces hand crafted JSON string with `JSON.dumps` to ensure correct escaping
* 🧪 adds unit tests to validate functionality 

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
