### PR TITLE
[BH-1794] Only run the deployment steps if previous have succeeded

### DIFF
--- a/azure-pipeline-templates/deploy.yml
+++ b/azure-pipeline-templates/deploy.yml
@@ -130,7 +130,7 @@ steps:
       helmVersionToInstall: '3.2.0'
   - task: HelmDeploy@0
     displayName: 'Add helm repository'
-    condition: ne('${{ parameters.dryRun }}', 'True')
+    condition: and(succeeded(), ne('${{ parameters.dryRun }}', 'True'))
     inputs:
       connectionType: 'Kubernetes Service Connection'
       kubernetesServiceConnection: ${{parameters.kubernetesServiceConnection}}
@@ -138,7 +138,7 @@ steps:
       arguments: 'add dct https://digitalcampaignsstorage.blob.core.windows.net/helm/'
   - task: HelmDeploy@0
     displayName: 'Update Helm Repository'
-    condition: ne('${{ parameters.dryRun }}', 'True')
+    condition: and(succeeded(), ne('${{ parameters.dryRun }}', 'True'))
     inputs:
       connectionType: 'Kubernetes Service Connection'
       kubernetesServiceConnection: ${{parameters.kubernetesServiceConnection}}
@@ -158,7 +158,7 @@ steps:
       arguments: '--install --dry-run --debug --repo https://digitalcampaignsstorage.blob.core.windows.net/helm/ --version 2.2.3 --create-namespace -f helm/values.yaml -f helm/extra-values.yaml --timeout 900s'
   - task: HelmDeploy@0
     displayName: 'Helm Upgrade'
-    condition: ne('${{ parameters.dryRun }}', 'True')
+    condition: and(succeeded(), ne('${{ parameters.dryRun }}', 'True'))
     inputs:
       connectionType: 'Kubernetes Service Connection'
       kubernetesServiceConnection: ${{parameters.kubernetesServiceConnection}}
@@ -173,7 +173,7 @@ steps:
     inputs:
       kubectlVersion: 'latest'
   - task: Kubernetes@1
-    condition: ne('${{ parameters.dryRun }}', 'True')
+    condition: and(succeeded(), ne('${{ parameters.dryRun }}', 'True'))
     inputs:
       connectionType: 'Kubernetes Service Connection'
       kubernetesServiceEndpoint: ${{parameters.kubernetesServiceEndPoint}}


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/BH-1794

## Description

Currently, if we cannot connect to the kubernetes cluster due to an agent not being on the IP allow list, we end up having to wait for long timeouts on tasks we know will fail. This PR:
* 🛑 only runs deployment tasks if previous ones have been successful

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
