### PR TITLE
CV-1344 session cookie missing security flags

### DIFF
--- a/campaignresourcecentre/settings/base.py
+++ b/campaignresourcecentre/settings/base.py
@@ -697,6 +697,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_SAVE_EVERY_REQUEST = True
 # expires cookies after 30 mins
 SESSION_COOKIE_AGE = 3600
+
 # Enabled as it was identified in Pen test as a problem
 # https://docs.djangoproject.com/en/5.2/ref/settings/#session-cookie-httponly
 SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1344

## Description

The secure flag should be set for all cookies containing sensitive information or used to control a
user’s authenticated session. This can be done by adding ‘; secure’ to the end of a cookie in a SetCookie HTTP response header.

The ‘SameSite’ flag should be set to strict for all session cookies. To do this, add ‘; SameSite=Strict’
to the end of the cookie in a ‘Set-Cookie’ HTTP response header.

The HTTPOnly flag should be set for all session cookies. To do this, add '; HTTPOnly' to the end of
the cookie in a Set-Cookie HTTP response header.
## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
