### PR TITLE
[CV-1357] Ignore CVE-2025-57833 while we look to upgrade to Django LTS

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Will upgrade Django as part of CV-1357
+CVE-2025-57833


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1357

## Description

We need to upgrade Django LTS, but in the meantime, we can ignore the vulnerability as part of the deployment pipeline

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
