### PR TITLE
CV-1426: blob data contributor role to identities

### DIFF
--- a/terraform/src/common/data.tf
+++ b/terraform/src/common/data.tf
@@ -32,7 +32,7 @@ data "azurerm_cdn_frontdoor_profile" "frontdoor" { # The frontdoor profile is on
   resource_group_name = replace(var.resource_group, "-ukw", "-uks")
 }
 
-data "azurerm_user_assigned_identity" "wagtail" {
+data "azurerm_user_assigned_identity" "apps" {
   name                = "${local.org}-${local.app}-id-${var.env}"
   resource_group_name = data.azurerm_resource_group.rg.name
 }

--- a/terraform/src/common/data.tf
+++ b/terraform/src/common/data.tf
@@ -31,3 +31,8 @@ data "azurerm_cdn_frontdoor_profile" "frontdoor" { # The frontdoor profile is on
   name                = "${local.org}-${local.app}-afd-${var.env}"
   resource_group_name = replace(var.resource_group, "-ukw", "-uks")
 }
+
+data "azurerm_user_assigned_identity" "wagtail" {
+  name                = "${local.org}-${local.app}-id-${var.env}"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}

--- a/terraform/src/common/storage_account.tf
+++ b/terraform/src/common/storage_account.tf
@@ -20,10 +20,19 @@ resource "azurerm_storage_account" "crc_cms" {
   }
 }
 
-resource "azurerm_role_assignment" "storage_blob_contributor_pipeline_identity" {
+resource "azurerm_role_assignment" "storage_blob_contributor_app_identity" {
   for_each = azurerm_storage_account.crc_cms
 
   principal_id         = data.azurerm_client_config.current.object_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = each.value.id
+  principal_type       = "ServicePrincipal"
+}
+
+resource "azurerm_role_assignment" "storage_blob_contributor_pipeline_identity" {
+  for_each = azurerm_storage_account.crc_cms
+
+  principal_id         = data.azurerm_user_assigned_identity.wagtail.principal_id
   role_definition_name = "Storage Blob Data Contributor"
   scope                = each.value.id
   principal_type       = "ServicePrincipal"

--- a/terraform/src/common/storage_account.tf
+++ b/terraform/src/common/storage_account.tf
@@ -1,9 +1,3 @@
-import {
-  for_each = local.storage_account
-  to       = azurerm_storage_account.crc_cms[each.key]
-  id       = "${data.azurerm_resource_group.rg.id}/providers/Microsoft.Storage/storageAccounts/${each.value}"
-}
-
 resource "azurerm_storage_account" "crc_cms" {
   for_each = local.storage_account
 
@@ -26,10 +20,13 @@ resource "azurerm_storage_account" "crc_cms" {
   }
 }
 
-import {
-  for_each = local.storage_container
-  to       = azurerm_storage_container.crc_cms[each.key]
-  id       = "${data.azurerm_resource_group.rg.id}/providers/Microsoft.Storage/storageAccounts/${each.value}/blobServices/default/containers/${each.key}"
+resource "azurerm_role_assignment" "storage_blob_contributor_pipeline_identity" {
+  for_each = azurerm_storage_account.crc_cms
+
+  principal_id         = data.azurerm_client_config.current.object_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = each.value.id
+  principal_type       = "ServicePrincipal"
 }
 
 #trivy:ignore:avd-azu-0007 storage container public access is enabled as it serves the assets for the website

--- a/terraform/src/common/storage_account.tf
+++ b/terraform/src/common/storage_account.tf
@@ -20,7 +20,7 @@ resource "azurerm_storage_account" "crc_cms" {
   }
 }
 
-resource "azurerm_role_assignment" "storage_blob_contributor_app_identity" {
+resource "azurerm_role_assignment" "storage_blob_contributor_pipeline_identity" {
   for_each = azurerm_storage_account.crc_cms
 
   principal_id         = data.azurerm_client_config.current.object_id
@@ -29,10 +29,10 @@ resource "azurerm_role_assignment" "storage_blob_contributor_app_identity" {
   principal_type       = "ServicePrincipal"
 }
 
-resource "azurerm_role_assignment" "storage_blob_contributor_pipeline_identity" {
+resource "azurerm_role_assignment" "storage_blob_contributor_apps_identity" {
   for_each = azurerm_storage_account.crc_cms
 
-  principal_id         = data.azurerm_user_assigned_identity.wagtail.principal_id
+  principal_id         = data.azurerm_user_assigned_identity.apps.principal_id
   role_definition_name = "Storage Blob Data Contributor"
   scope                = each.value.id
   principal_type       = "ServicePrincipal"


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1425
- https://ukhsa.atlassian.net/browse/CV-1426

## Description

Add "Storage Blob Data Contributor" roles to both:
- Pipeline identity
- Managed identity used by Container Apps and Container App Job (init job)

This will allow us to stop using Azure Storage Keys

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
