### PR TITLE
CV-1438 Remove campaign topics column in confirmation table, check both latest live and draft revision

### DIFF
--- a/campaignresourcecentre/campaigns/models.py
+++ b/campaignresourcecentre/campaigns/models.py
@@ -75,15 +75,20 @@ def _taxonomy_contains_code(taxonomy_json, code):
     return bool(re.search(rf'"code"\s*:\s*"{re.escape(code)}"', taxonomy_json))
 
 
-def _any_revision_has_topic(page, code):
-    """Check both live and draft revisions for the topic code."""
+def _latest_draft_revision_has_topic(page, code):
+    """Check the latest (draft) revision for the topic code."""
     latest = page.latest_revision
-    draft = (
+    taxonomy = (
         latest.content.get("taxonomy_json", "") if latest else page.taxonomy_json or ""
     )
+    return _taxonomy_contains_code(taxonomy, code)
+
+
+def _latest_live_revision_has_topic(page, code):
+    """Check the live (published) revision for the topic code."""
     live_rev = getattr(page, "live_revision", None)
-    live = live_rev.content.get("taxonomy_json", "") if live_rev else ""
-    return _taxonomy_contains_code(draft, code) or _taxonomy_contains_code(live, code)
+    taxonomy = live_rev.content.get("taxonomy_json", "") if live_rev else ""
+    return _taxonomy_contains_code(taxonomy, code)
 
 
 def pages_with_topic(code):
@@ -94,9 +99,20 @@ def pages_with_topic(code):
     resource_pages = ResourcePage.objects.select_related(
         "latest_revision", "live_revision"
     ).all()
+
     return (
-        [page for page in campaign_pages if _any_revision_has_topic(page, code)],
-        [page for page in resource_pages if _any_revision_has_topic(page, code)],
+        [
+            page
+            for page in campaign_pages
+            if _latest_draft_revision_has_topic(page, code)
+            or _latest_live_revision_has_topic(page, code)
+        ],
+        [
+            page
+            for page in resource_pages
+            if _latest_draft_revision_has_topic(page, code)
+            or _latest_live_revision_has_topic(page, code)
+        ],
     )
 
 

--- a/campaignresourcecentre/campaigns/models.py
+++ b/campaignresourcecentre/campaigns/models.py
@@ -67,7 +67,11 @@ class Topic(models.Model):
 
 
 def _taxonomy_contains_code(taxonomy_json, code):
-    """Check if a taxonomy JSON string contains the given topic code."""
+    """Check if a taxonomy JSON string contains the given topic code.
+
+    Handles both python json.dumps ("code": "EATING") and
+    JavaScript JSON.stringify ("code":"EATING") whitespace variants.
+    """
     return bool(re.search(rf'"code"\s*:\s*"{re.escape(code)}"', taxonomy_json))
 
 

--- a/campaignresourcecentre/campaigns/models.py
+++ b/campaignresourcecentre/campaigns/models.py
@@ -32,6 +32,7 @@ from campaignresourcecentre.core.templatetags.json_lookup import get_taxonomies
 
 from .blocks import CampaignDetailsBlock, CampaignsPageBlocks, CommonBlocks
 import logging
+import re
 
 HOME_PAGE_NAME = "home.HomePage"
 CAMPAIGN_PAGE_NAME = "campaigns.CampaignPage"
@@ -65,43 +66,56 @@ class Topic(models.Model):
         self.code = self.code.strip()
 
 
-def topic_code_filter(code):
-    """
-    Handles the whitespace difference between json.dumps (Python)
-    ("code": "X") and JSON.stringify (JavaScript)
-    ("code":"X").
-    """
-    from django.db.models import Q
+def _taxonomy_contains_code(taxonomy_json, code):
+    """Check if a taxonomy JSON string contains the given topic code."""
+    return bool(re.search(rf'"code"\s*:\s*"{re.escape(code)}"', taxonomy_json))
 
-    return Q(taxonomy_json__contains=f'"code": "{code}"') | Q(
-        taxonomy_json__contains=f'"code":"{code}"'
+
+def _any_revision_has_topic(page, code):
+    """Check both live and draft revisions of the page for the topic code."""
+    if _taxonomy_contains_code(_latest_taxonomy_json(page), code):
+        return True
+
+    live_revision = getattr(page, "live_revision", None)
+    has_separate_draft = (
+        page.live
+        and live_revision
+        and live_revision.id != getattr(page.latest_revision, "id", None)
     )
+    if has_separate_draft:
+        live_taxonomy = live_revision.content.get("taxonomy_json", "")
+        return _taxonomy_contains_code(live_taxonomy, code)
+
+    return False
 
 
-def _revision_has_topic(page, code):
-    """Check whether a page's latest revision contains the given topic code.
+def _latest_taxonomy_json(page):
+    """Return the taxonomy_json string from the page's latest revision.
 
-    The page table row only updates on publish, so we read from the
-    latest revision instead. This means both draft and published pages
-    are included only if their most recent revision still has the topic.
+    Falls back to the page table row if no revision exists.
     """
     revision = page.latest_revision
-    taxonomy = (
-        revision.content.get("taxonomy_json", "")
-        if revision
-        else page.taxonomy_json or ""
-    )
-    return f'"code": "{code}"' in taxonomy or f'"code":"{code}"' in taxonomy
+    if revision:
+        return revision.content.get("taxonomy_json", "")
+    return page.taxonomy_json or ""
+
+
+def latest_taxonomy(page):
+    """Return the parsed taxonomy list from the page's latest revision."""
+    return json.loads(_latest_taxonomy_json(page) or "[]")
 
 
 def pages_with_topic(code):
-    """Return (campaigns, resources) whose latest revision has the topic."""
-    filt = topic_code_filter(code)
-    campaign_pages = CampaignPage.objects.filter(filt)
-    resource_pages = ResourcePage.objects.filter(filt)
+    """Return (campaigns, resources) where any current version has the topic."""
+    campaign_pages = CampaignPage.objects.select_related(
+        "latest_revision", "live_revision"
+    ).all()
+    resource_pages = ResourcePage.objects.select_related(
+        "latest_revision", "live_revision"
+    ).all()
     return (
-        [page for page in campaign_pages if _revision_has_topic(page, code)],
-        [page for page in resource_pages if _revision_has_topic(page, code)],
+        [page for page in campaign_pages if _any_revision_has_topic(page, code)],
+        [page for page in resource_pages if _any_revision_has_topic(page, code)],
     )
 
 

--- a/campaignresourcecentre/campaigns/models.py
+++ b/campaignresourcecentre/campaigns/models.py
@@ -72,37 +72,14 @@ def _taxonomy_contains_code(taxonomy_json, code):
 
 
 def _any_revision_has_topic(page, code):
-    """Check both live and draft revisions of the page for the topic code."""
-    if _taxonomy_contains_code(_latest_taxonomy_json(page), code):
-        return True
-
-    live_revision = getattr(page, "live_revision", None)
-    has_separate_draft = (
-        page.live
-        and live_revision
-        and live_revision.id != getattr(page.latest_revision, "id", None)
+    """Check both live and draft revisions for the topic code."""
+    latest = page.latest_revision
+    draft = (
+        latest.content.get("taxonomy_json", "") if latest else page.taxonomy_json or ""
     )
-    if has_separate_draft:
-        live_taxonomy = live_revision.content.get("taxonomy_json", "")
-        return _taxonomy_contains_code(live_taxonomy, code)
-
-    return False
-
-
-def _latest_taxonomy_json(page):
-    """Return the taxonomy_json string from the page's latest revision.
-
-    Falls back to the page table row if no revision exists.
-    """
-    revision = page.latest_revision
-    if revision:
-        return revision.content.get("taxonomy_json", "")
-    return page.taxonomy_json or ""
-
-
-def latest_taxonomy(page):
-    """Return the parsed taxonomy list from the page's latest revision."""
-    return json.loads(_latest_taxonomy_json(page) or "[]")
+    live_rev = getattr(page, "live_revision", None)
+    live = live_rev.content.get("taxonomy_json", "") if live_rev else ""
+    return _taxonomy_contains_code(draft, code) or _taxonomy_contains_code(live, code)
 
 
 def pages_with_topic(code):

--- a/campaignresourcecentre/campaigns/templates/campaigns/delete_topic.html
+++ b/campaignresourcecentre/campaigns/templates/campaigns/delete_topic.html
@@ -9,12 +9,12 @@
             <p>{{ view.confirmation_message }}</p>
 
             {% if tagged_pages %}
+                <p class="help-text">{% trans "This includes pages where the topic appears on the live version or in a draft. Please check both before removing the topic." %}</p>
                 <table class="listing">
                     <thead>
                         <tr>
                             <th>{% trans "Title" %}</th>
                             <th>{% trans "Type" %}</th>
-                            <th>{% trans "Topic tags" %}</th>
                             <th>{% trans "Status" %}</th>
                         </tr>
                     </thead>
@@ -27,7 +27,6 @@
                                     </div>
                                 </td>
                                 <td>{{ item.page_type }}</td>
-                                <td>{{ item.topic_tags }}</td>
                                 <td>
                                     {% include 'wagtailadmin/shared/page_status_tag.html' with page=item.page %}
                                 </td>

--- a/campaignresourcecentre/campaigns/tests.py
+++ b/campaignresourcecentre/campaigns/tests.py
@@ -155,6 +155,10 @@ class PagesWithTopicTest(TestCase):
 
     def test_draft_removal_still_finds_live_page(self):
         """A draft that removes a tag does not hide the live page."""
+        # Publish so the page has a live_revision with EATING
+        self.campaign_page.save_revision().publish()
+        self.campaign_page.refresh_from_db()
+        # Now create a draft that removes EATING
         self.campaign_page.taxonomy_json = json.dumps(
             [{"code": "PHYSICALACTIVITY", "label": "Physical Activity"}]
         )

--- a/campaignresourcecentre/campaigns/tests.py
+++ b/campaignresourcecentre/campaigns/tests.py
@@ -153,8 +153,19 @@ class PagesWithTopicTest(TestCase):
         self.assertIn(self.campaign_page, campaigns)
         self.assertIn(self.resource_page, resources)
 
-    def test_draft_removal_excludes_page(self):
-        """When a tag is removed in a draft save, the page is excluded."""
+    def test_draft_removal_still_finds_live_page(self):
+        """A draft that removes a tag does not hide the live page."""
+        self.campaign_page.taxonomy_json = json.dumps(
+            [{"code": "PHYSICALACTIVITY", "label": "Physical Activity"}]
+        )
+        self.campaign_page.save_revision()
+        campaigns, _ = pages_with_topic("EATING")
+        self.assertEqual(len(campaigns), 1)
+
+    def test_draft_only_removal_excludes_page(self):
+        """A draft-only page that removes a tag is excluded."""
+        self.campaign_page.live = False
+        self.campaign_page.save()
         self.campaign_page.taxonomy_json = json.dumps(
             [{"code": "PHYSICALACTIVITY", "label": "Physical Activity"}]
         )

--- a/campaignresourcecentre/campaigns/views.py
+++ b/campaignresourcecentre/campaigns/views.py
@@ -7,7 +7,6 @@ from campaignresourcecentre.campaigns.models import (
     CampaignHubPage as campaign,
     pages_with_topic,
 )
-from campaignresourcecentre.core.templatetags.json_lookup import get_taxonomies
 from django.views.decorators.http import require_http_methods
 
 
@@ -55,14 +54,12 @@ class TopicDeleteView(DeleteView):
             {
                 "page": p,
                 "page_type": "Campaign",
-                "topic_tags": get_taxonomies(p.taxonomy, "TOPIC"),
             }
             for p in campaign_pages
         ] + [
             {
                 "page": p,
                 "page_type": "Resource",
-                "topic_tags": get_taxonomies(p.taxonomy, "TOPIC"),
             }
             for p in resource_pages
         ]


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1438

## Description

Previous problem:
The delete confirmation only checked the page table row to find pages using a topic. This missed pages where tags were added via bulk actions (which only write to revisions, not the page table). It also only checked the latest revision, so if a draft removed a tag that was still on the live version, that page wouldn't appear in the confirmation - risking deletion of a topic still in use on the published site.

Fix:
Now we check both the live revision and the latest (draft) revision for every page. If either contains the topic, the page appears in the confirmation table. Also removed the Topic Tags column (it was misleading since the page table and revision could show different tags) and added hint text explaining that both live and draft versions are checked.

`Summary: Essentially regardless of page status (draft or live), if the topic is there, the user cannot delete the campaign tag until they've removed it from the relevant page`


## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
