### PR TITLE
CV-1426: remove storage key and publish db dumps to new backups storage account

### DIFF
--- a/azure-pipeline-templates/db-sync.yml
+++ b/azure-pipeline-templates/db-sync.yml
@@ -31,6 +31,10 @@ parameters:
     default: false
     displayName: Sync To Staging Env
 
+variables:
+  - name: AZURE_STORAGE_AUTH_MODE
+    value: login
+
 resources:
   - repo: self
 
@@ -48,8 +52,8 @@ stages:
               SecretsFilter: db-pass, db-name, db-host, db-user
           - template: templates/db-sync-download-dump.yaml
             parameters:
-              dumpPrefix: prod
-              publishDump: true
+              environment: production
+              publishFullDbDump: True
 
   - stage: UploadProdDumpToBlob
     displayName: Backup Production Database
@@ -61,12 +65,8 @@ stages:
         steps:
           - template: templates/db-sync-upload-blob.yaml
             parameters:
-              azureStorageSubscription: dct-crccms-prod
-              StorageAccountNameDbDump: $(StorageAccountNameDbDump)
-              BlobStorageKeyDbDump: $(BlobStorageKeyDbDump)
-              BlobStorageContainerNameDbDump: $(BlobStorageContainerNameDbDump)
               useArtifact: true
-              dumpPrefix: prod
+              environment: production
 
   - stage: CopyToReviewDB
     displayName: Copy to Review Database
@@ -78,7 +78,6 @@ stages:
         steps:
           - template: templates/db-sync-env-sync.yaml
             parameters:
-              azureStorageSubscription: nhsuk-dct-rg-dev-uks.campaign-resource-centre-v3
               azureVaultSubscription: dct-crccms-dev
               VaultId: dct-crc-kv-app-dev-uks
               environment: review
@@ -94,7 +93,6 @@ stages:
         steps:
           - template: templates/db-sync-env-sync.yaml
             parameters:
-              azureStorageSubscription: nhsuk-dct-rg-dev-uks.campaign-resource-centre-v3
               azureVaultSubscription: dct-crccms-int
               VaultId: dct-crc-kv-app-int-uks
               environment: integration
@@ -113,7 +111,6 @@ stages:
           - template: templates/db-sync-env-sync.yaml
             parameters:
               azureVaultSubscription: dct-crccms-stag
-              azureStorageSubscription: dct-crccms-stag
               VaultId: dct-crc-kv-app-stag-uks
               environment: staging
               env: stag

--- a/azure-pipeline-templates/db-sync.yml
+++ b/azure-pipeline-templates/db-sync.yml
@@ -53,7 +53,6 @@ stages:
           - template: templates/db-sync-download-dump.yaml
             parameters:
               environment: production
-              publishFullDbDump: True
 
   - stage: UploadProdDumpToBlob
     displayName: Backup Production Database

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -1,32 +1,32 @@
 steps:
-- script: |
-    set -x
-    set -e
-    docker run \
-      -e PGHOST="$(db-host)" \
-      -e PGPASSWORD="$(db-pass)" \
-      -e PGUSER="$(db-user)" \
-      postgres:16 \
-      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.dumpPrefix}}-db-dump.dump
-  condition: ${{ eq(parameters.usersOnly, True) }}
-  name: 'Create_${{parameters.dumpPrefix}}_Copy'
-  displayName: 'Dump ${{parameters.dumpPrefix}} (Users only)'
+  ${{ if eq(parameters.usersOnly, True) }}:
+    - script: |
+        set -x
+        set -e
+        docker run \
+          -e PGHOST="$(db-host)" \
+          -e PGPASSWORD="$(db-pass)" \
+          -e PGUSER="$(db-user)" \
+          postgres:16 \
+          pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}-db-dump.dump
+      name: 'Create_${{parameters.environment}}_Copy'
+      displayName: 'Dump ${{parameters.environment}} (Users only)'
 
-- script: |
-    set -x
-    set -e
-    docker run \
-      -e PGHOST="$(db-host)" \
-      -e PGPASSWORD="$(db-pass)" \
-      -e PGUSER="$(db-user)" \
-      postgres:16 \
-      pg_dump -Fc "$(db-name)" > ${{parameters.dumpPrefix}}-db-dump.dump
-  condition: ${{ ne(parameters.usersOnly, True) }}
-  name: 'Create_${{parameters.dumpPrefix}}_DBCopy'
-  displayName: 'Dump ${{parameters.dumpPrefix}} (Full DB)'
+  ${{ else }}:
+    - script: |
+        set -x
+        set -e
+        docker run \
+          -e PGHOST="$(db-host)" \
+          -e PGPASSWORD="$(db-pass)" \
+          -e PGUSER="$(db-user)" \
+          postgres:16 \
+          pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
+      name: 'Create_${{parameters.environment}}_DBCopy'
+      displayName: 'Dump ${{parameters.environment}} (Full DB)'
 
 - task: PublishPipelineArtifact@1
-  condition: ${{ eq(parameters.publishDump, True) }}
+  condition: ${{ and(eq(parameters.publishFullDbDump, True), ne(parameters.usersOnly, True)) }}
   inputs:
-    targetPath: $(System.DefaultWorkingDirectory)/${{parameters.dumpPrefix}}-db-dump.dump
-    artifactName: '${{parameters.dumpPrefix}}-db.dump'
+    targetPath: $(System.DefaultWorkingDirectory)/${{parameters.environment}}-db-dump.dump
+    artifactName: '${{parameters.environment}}-db.dump'

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -1,29 +1,29 @@
 steps:
-${{ if eq(parameters.usersOnly, True) }}:
-  - script: |
-      set -x
-      set -e
-      docker run \
-        -e PGHOST="$(db-host)" \
-        -e PGPASSWORD="$(db-pass)" \
-        -e PGUSER="$(db-user)" \
-        postgres:16 \
-        pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
-    name: 'Create_${{parameters.environment}}_users_Copy'
-    displayName: 'Dump ${{parameters.environment}}_users (Users only)'
+- script: |
+    set -x
+    set -e
+    docker run \
+      -e PGHOST="$(db-host)" \
+      -e PGPASSWORD="$(db-pass)" \
+      -e PGUSER="$(db-user)" \
+      postgres:16 \
+      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
+  name: 'Create_${{parameters.environment}}_users_Copy'
+  condition: ${{ eq(parameters.usersOnly, True) }}
+  displayName: 'Dump ${{parameters.environment}}_users (Users only)'
 
-${{ else }}:
-  - script: |
-      set -x
-      set -e
-      docker run \
-        -e PGHOST="$(db-host)" \
-        -e PGPASSWORD="$(db-pass)" \
-        -e PGUSER="$(db-user)" \
-        postgres:16 \
-        pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
-    name: 'Create_${{parameters.environment}}_DBCopy'
-    displayName: 'Dump ${{parameters.environment}} (Full DB)'
+- script: |
+    set -x
+    set -e
+    docker run \
+      -e PGHOST="$(db-host)" \
+      -e PGPASSWORD="$(db-pass)" \
+      -e PGUSER="$(db-user)" \
+      postgres:16 \
+      pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
+  name: 'Create_${{parameters.environment}}_DBCopy'
+  condition: ${{ ne(parameters.usersOnly, True) }}
+  displayName: 'Dump ${{parameters.environment}} (Full DB)'
 
 - task: PublishPipelineArtifact@1
   condition: ${{ and(eq(parameters.publishFullDbDump, True), ne(parameters.usersOnly, True)) }}

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -7,26 +7,11 @@ steps:
       -e PGPASSWORD="$(db-pass)" \
       -e PGUSER="$(db-user)" \
       postgres:16 \
-      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
-  name: 'Create_${{parameters.environment}}_users_Copy'
-  condition: ${{ eq(parameters.usersOnly, True) }}
-  displayName: 'Dump ${{parameters.environment}}_users (Users only)'
-
-- script: |
-    set -x
-    set -e
-    docker run \
-      -e PGHOST="$(db-host)" \
-      -e PGPASSWORD="$(db-pass)" \
-      -e PGUSER="$(db-user)" \
-      postgres:16 \
       pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
   name: 'Create_${{parameters.environment}}_DBCopy'
-  condition: ${{ ne(parameters.usersOnly, True) }}
   displayName: 'Dump ${{parameters.environment}} (Full DB)'
 
 - task: PublishPipelineArtifact@1
-  condition: ${{ and(eq(parameters.publishFullDbDump, True), ne(parameters.usersOnly, True)) }}
   inputs:
     targetPath: $(System.DefaultWorkingDirectory)/${{parameters.environment}}-db-dump.dump
     artifactName: '${{parameters.environment}}-db.dump'

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -1,29 +1,29 @@
 steps:
-  ${{ if eq(parameters.usersOnly, True) }}:
-    - script: |
-        set -x
-        set -e
-        docker run \
-          -e PGHOST="$(db-host)" \
-          -e PGPASSWORD="$(db-pass)" \
-          -e PGUSER="$(db-user)" \
-          postgres:16 \
-          pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}-db-dump.dump
-      name: 'Create_${{parameters.environment}}_Copy'
-      displayName: 'Dump ${{parameters.environment}} (Users only)'
+${{ if eq(parameters.usersOnly, True) }}:
+  - script: |
+      set -x
+      set -e
+      docker run \
+        -e PGHOST="$(db-host)" \
+        -e PGPASSWORD="$(db-pass)" \
+        -e PGUSER="$(db-user)" \
+        postgres:16 \
+        pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
+    name: 'Create_${{parameters.environment}}_users_Copy'
+    displayName: 'Dump ${{parameters.environment}}_users (Users only)'
 
-  ${{ else }}:
-    - script: |
-        set -x
-        set -e
-        docker run \
-          -e PGHOST="$(db-host)" \
-          -e PGPASSWORD="$(db-pass)" \
-          -e PGUSER="$(db-user)" \
-          postgres:16 \
-          pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
-      name: 'Create_${{parameters.environment}}_DBCopy'
-      displayName: 'Dump ${{parameters.environment}} (Full DB)'
+${{ else }}:
+  - script: |
+      set -x
+      set -e
+      docker run \
+        -e PGHOST="$(db-host)" \
+        -e PGPASSWORD="$(db-pass)" \
+        -e PGUSER="$(db-user)" \
+        postgres:16 \
+        pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
+    name: 'Create_${{parameters.environment}}_DBCopy'
+    displayName: 'Dump ${{parameters.environment}} (Full DB)'
 
 - task: PublishPipelineArtifact@1
   condition: ${{ and(eq(parameters.publishFullDbDump, True), ne(parameters.usersOnly, True)) }}

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -7,9 +7,11 @@ steps:
       -e PGPASSWORD="$(db-pass)" \
       -e PGUSER="$(db-user)" \
       postgres:16 \
-      pg_dump -Fc "$(db-name)" > ${{parameters.environment}}-db-dump.dump
+      pg_dump -Fc "$(db-name)" > ${ENVIRONMENT}-db-dump.dump
   name: 'Create_${{parameters.environment}}_DBCopy'
   displayName: 'Dump ${{parameters.environment}} (Full DB)'
+  env:
+    ENVIRONMENT: ${{parameters.environment}}
 
 - task: PublishPipelineArtifact@1
   inputs:

--- a/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
@@ -1,0 +1,12 @@
+steps:
+- script: |
+    set -x
+    set -e
+    docker run \
+      -e PGHOST="$(db-host)" \
+      -e PGPASSWORD="$(db-pass)" \
+      -e PGUSER="$(db-user)" \
+      postgres:16 \
+      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
+  name: 'Create_${{parameters.environment}}_users_Copy'
+  displayName: 'Dump ${{parameters.environment}}_users (Users only)'

--- a/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
@@ -7,6 +7,8 @@ steps:
       -e PGPASSWORD="$(db-pass)" \
       -e PGUSER="$(db-user)" \
       postgres:16 \
-      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${{parameters.environment}}_users-db-dump.dump
+      pg_dump -Fc "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" > ${ENVIRONMENT}_users-db-dump.dump
   name: 'Create_${{parameters.environment}}_users_Copy'
   displayName: 'Dump ${{parameters.environment}}_users (Users only)'
+  env:
+    ENVIRONMENT: ${{parameters.environment}}

--- a/azure-pipeline-templates/templates/db-sync-env-sync.yaml
+++ b/azure-pipeline-templates/templates/db-sync-env-sync.yaml
@@ -15,29 +15,23 @@ steps:
 
 - template: ./db-sync-download-dump.yaml
   parameters:
-    dumpPrefix: ${{ parameters.environment }}_users
+    environment: ${{ parameters.environment }}
     usersOnly: True
 
 - template: ./db-sync-restore-db.yaml
   parameters:
-    dumpPrefix: prod
-    useArtifact: true
+    environment: production
+    useArtifact: True
 
 - template: ./db-sync-restore-users.yaml
   parameters:
-    dumpPrefix: ${{ parameters.environment }}_users
+    environment: ${{ parameters.environment }}_users
 
 - template: ./db-sync-download-dump.yaml
   parameters:
-    dumpPrefix: ${{ parameters.environment }}
-    # Added for now so that pipeline artifact can be used for local dev until upload available
-    publishDump: true
+    environment: ${{ parameters.environment }}
+    publishFullDbDump: True
 
-# TODO: once CRC 'feat' subscription established, upload db dump to it for use in local dev
-# - template: ./db-sync-upload-blob.yaml
-#   parameters:
-#     azureStorageSubscription: ${{ parameters.azureStorageSubscription}}
-#     StorageAccountNameDbDump: $(StorageAccountNameDbDump)
-#     BlobStorageKeyDbDump: $(BlobStorageKeyDbDump)
-#     BlobStorageContainerNameDbDump: $(BlobStorageContainerNameDbDump)
-#     dumpPrefix: ${{ parameters.environment }}
+- template: ./db-sync-upload-blob.yaml
+  parameters:
+    environment: ${{ parameters.environment }}

--- a/azure-pipeline-templates/templates/db-sync-env-sync.yaml
+++ b/azure-pipeline-templates/templates/db-sync-env-sync.yaml
@@ -13,10 +13,9 @@ steps:
     KeyVaultName: dct-crccms-kv2-${{parameters.env}}-uks
     SecretsFilter: postgresqlAdminUser, postgresqlAdminPassword
 
-- template: ./db-sync-download-dump.yaml
+- template: ./db-sync-download-users-dump.yaml
   parameters:
     environment: ${{ parameters.environment }}
-    usersOnly: True
 
 - template: ./db-sync-restore-db.yaml
   parameters:
@@ -30,7 +29,6 @@ steps:
 - template: ./db-sync-download-dump.yaml
   parameters:
     environment: ${{ parameters.environment }}
-    publishFullDbDump: True
 
 - template: ./db-sync-upload-blob.yaml
   parameters:

--- a/azure-pipeline-templates/templates/db-sync-restore-db.yaml
+++ b/azure-pipeline-templates/templates/db-sync-restore-db.yaml
@@ -61,12 +61,13 @@ steps:
       -e PGHOST="$(db-host)" \
       -e PGUSER="$(postgresqlAdminUser)" \
       -e PGPASSWORD \
-      -v $(pwd)/${{parameters.environment}}-db-dump.dump:/${{parameters.environment}}-db.dump \
+      -v $(pwd)/${ENVIRONMENT}-db-dump.dump:/${ENVIRONMENT}-db.dump \
       postgres:16 \
-      pg_restore --no-acl --no-owner -d "$(db-name)" ${{parameters.environment}}-db.dump
+      pg_restore --no-acl --no-owner -d "$(db-name)" ${ENVIRONMENT}-db.dump
   displayName: Copy ${{parameters.environment}} to target database
   env:
     PGPASSWORD: $(postgresqlAdminPassword)
+    ENVIRONMENT: ${{parameters.environment}}
 
 - script: |
     set -e

--- a/azure-pipeline-templates/templates/db-sync-restore-db.yaml
+++ b/azure-pipeline-templates/templates/db-sync-restore-db.yaml
@@ -52,7 +52,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   condition: ${{ eq(parameters.useArtifact, True) }}
   inputs:
-    artifact: ${{parameters.dumpPrefix}}-db.dump
+    artifact: ${{parameters.environment}}-db.dump
     path: $(Build.SourcesDirectory)
 
 - script: |
@@ -61,10 +61,10 @@ steps:
       -e PGHOST="$(db-host)" \
       -e PGUSER="$(postgresqlAdminUser)" \
       -e PGPASSWORD \
-      -v $(pwd)/${{parameters.dumpPrefix}}-db-dump.dump:/${{parameters.dumpPrefix}}-db.dump \
+      -v $(pwd)/${{parameters.environment}}-db-dump.dump:/${{parameters.environment}}-db.dump \
       postgres:16 \
-      pg_restore --no-acl --no-owner -d "$(db-name)" ${{parameters.dumpPrefix}}-db.dump
-  displayName: Copy ${{parameters.dumpPrefix}} to target database
+      pg_restore --no-acl --no-owner -d "$(db-name)" ${{parameters.environment}}-db.dump
+  displayName: Copy ${{parameters.environment}} to target database
   env:
     PGPASSWORD: $(postgresqlAdminPassword)
 

--- a/azure-pipeline-templates/templates/db-sync-restore-users.yaml
+++ b/azure-pipeline-templates/templates/db-sync-restore-users.yaml
@@ -148,10 +148,13 @@ steps:
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \
       -e PGUSER="$(db-user)" \
-      -v $(pwd)/${{parameters.environment}}-db-dump.dump:/${{parameters.environment}}-db.dump \
+      -v $(pwd)/${ENVIRONMENT}-db-dump.dump:/${ENVIRONMENT}-db.dump \
       postgres:16 \
-      pg_restore --no-acl --no-owner --data-only -d "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" ${{parameters.environment}}-db.dump
+      pg_restore --no-acl --no-owner --data-only -d "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" ${ENVIRONMENT}-db.dump
   displayName: Restore ${{parameters.environment}} users to target database
+  env:
+    ENVIRONMENT: ${{parameters.environment}}
+
 
 - script: |
     set -e

--- a/azure-pipeline-templates/templates/db-sync-restore-users.yaml
+++ b/azure-pipeline-templates/templates/db-sync-restore-users.yaml
@@ -148,10 +148,10 @@ steps:
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \
       -e PGUSER="$(db-user)" \
-      -v $(pwd)/${{parameters.dumpPrefix}}-db-dump.dump:/${{parameters.dumpPrefix}}-db.dump \
+      -v $(pwd)/${{parameters.environment}}-db-dump.dump:/${{parameters.environment}}-db.dump \
       postgres:16 \
-      pg_restore --no-acl --no-owner --data-only -d "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" ${{parameters.dumpPrefix}}-db.dump
-  displayName: Restore ${{parameters.dumpPrefix}} users to target database
+      pg_restore --no-acl --no-owner --data-only -d "$(db-name)" -t "users_user" -t "otp_totp_totpdevice" -t "users_user_groups" -t "users_user_user_permissions" -t "wagtailusers_userprofile" ${{parameters.environment}}-db.dump
+  displayName: Restore ${{parameters.environment}} users to target database
 
 - script: |
     set -e

--- a/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
+++ b/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
@@ -21,14 +21,16 @@ steps:
       set -e
 
       # Rename the data dump to contain timestamp before upload
-      mv ${{parameters.environment}}-db-dump.dump db-dump-$(currentDatestamp.Datestamp).dump
+      mv $ENVIRONMENT-db-dump.dump db-dump-$(currentDatestamp.Datestamp).dump
 
       # Save a copy to azure blob storage
       az storage blob upload \
         --account-name dctcrccmsbackupsdevuks \
-        --container-name ${{parameters.environment}} \
+        --container-name $ENVIRONMENT \
         --file db-dump-$(currentDatestamp.Datestamp).dump \
         --name db-dump-$(currentDatestamp.Datestamp).dump \
         --auth-mode login
   name: BlobStorageBackup
   displayName: Backup to Blob Storage
+  env:
+    ENVIRONMENT: ${{parameters.environment}}

--- a/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
+++ b/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
@@ -5,27 +5,15 @@ steps:
     echo "##vso[task.setvariable variable=Datestamp;isOutput=True]$date"
   name: currentDatestamp
 
-- bash: |
-    root=""
-    echo ${{parameters.dumpPrefix}}
-    if [ "${{parameters.dumpPrefix}}" = "prod" ]; then
-      echo "##vso[task.setvariable variable=folder;isOutput=True]$root"
-      echo "using root directory"
-    else
-      echo "##vso[task.setvariable variable=folder;isOutput=True]${{parameters.dumpPrefix}}/"
-      echo "using ${{parameters.dumpPrefix}} folder"
-    fi
-  name: environment
-
 - task: DownloadPipelineArtifact@2
   condition: ${{ eq(parameters.useArtifact, True) }}
   inputs:
-    artifact: ${{parameters.dumpPrefix}}-db.dump
+    artifact: ${{parameters.environment}}-db.dump
     path: $(Build.SourcesDirectory)
 
 - task: AzureCLI@2
   inputs:
-    azureSubscription: ${{parameters.azureStorageSubscription}}
+    azureSubscription: dct-crccms-dev
     scriptType: bash
     scriptLocation: inlineScript
     inlineScript: |
@@ -33,14 +21,14 @@ steps:
       set -e
 
       # Rename the data dump to contain timestamp before upload
-      mv ${{parameters.dumpPrefix}}-db-dump.dump db-dump-$(currentDatestamp.Datestamp).dump
+      mv ${{parameters.environment}}-db-dump.dump db-dump-$(currentDatestamp.Datestamp).dump
 
       # Save a copy to azure blob storage
       az storage blob upload \
-        --account-name ${{parameters.StorageAccountNameDbDump}} \
-        --account-key ${{parameters.BlobStorageKeyDbDump}} \
-        --container-name ${{parameters.BlobStorageContainerNameDbDump}} \
+        --account-name dctcrccmsbackupsdevuks \
+        --container-name ${{parameters.environment}} \
         --file db-dump-$(currentDatestamp.Datestamp).dump \
-        --name $(environment.folder)db-dump-$(currentDatestamp.Datestamp).dump
+        --name db-dump-$(currentDatestamp.Datestamp).dump \
+        --auth-mode login
   name: BlobStorageBackup
   displayName: Backup to Blob Storage

--- a/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
+++ b/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
@@ -1,6 +1,6 @@
 steps:
 - bash: |
-    date=`date "+%d-%m-%Y_%H:%M:%S"`
+    date=`date "+%d-%m-%Y_%H-%M-%S"`
     echo $date
     echo "##vso[task.setvariable variable=Datestamp;isOutput=True]$date"
   name: currentDatestamp

--- a/fabfile.py
+++ b/fabfile.py
@@ -297,14 +297,8 @@ def sync_db(c, env):
 
 def extract_datetime_from_blob(blob_properties):
     blob_name = blob_properties["name"]
-    datetime_in_name = (
-        blob_name.replace("db-dump-", "")
-        .replace(".dump", "")
-        .replace("review/", "")
-        .replace("integration/", "")
-        .replace("staging/", "")
-    )
-    return datetime.strptime(datetime_in_name, "%d-%m-%Y_%H:%M:%S")
+    datetime_in_name = blob_name.replace("db-dump-", "").replace(".dump", "")
+    return datetime.strptime(datetime_in_name, "%d-%m-%Y_%H-%M-%S")
 
 
 def delete_local_renditions(c, local_database_name=LOCAL_DATABASE_NAME):

--- a/fabfile.py
+++ b/fabfile.py
@@ -246,17 +246,15 @@ def import_data(c, database_filename):
 
 
 @task
-def sync_db(c, env, storageKey):
+def sync_db(c, env):
     if env in ["staging", "integration", "review"]:
         try:
             print(f"Determining latest {env} dump to download...")
             blobs = local(
                 f"""az storage blob list \
-                    -c crc-v3-backups \
-                    --prefix "{env}/" \
-                    --account-name digitalcampaignsstorage \
-                    --account-key "{storageKey}" \
-                    --auth-mode key""",
+                    -c {env} \
+                    --account-name dctcrccmsbackupsdevuks \
+                    --auth-mode login""",
                 warn=True,
                 hide=True,
             )
@@ -269,11 +267,10 @@ def sync_db(c, env, storageKey):
                     local(
                         f"""az storage blob download \
                             -f database_dumps/{env}-db.dump \
-                            -c crc-v3-backups \
+                            -c {env} \
                             -n {latest_blob['name']} \
-                            --account-name digitalcampaignsstorage \
-                            --account-key "{storageKey}" \
-                            --auth-mode key""",
+                            --account-name dctcrccmsbackupsdevuks \
+                            --auth-mode login""",
                         warn=True,
                         hide=True,
                     )
@@ -308,39 +305,6 @@ def extract_datetime_from_blob(blob_properties):
         .replace("staging/", "")
     )
     return datetime.strptime(datetime_in_name, "%d-%m-%Y_%H:%M:%S")
-
-
-@task
-def create_dump(c):
-    result = local(
-        """az pipelines release create \
-            --organization "https://dev.azure.com/nhsuk/" \
-            --project "dct.campaign-resource-centre-v3" \
-            --definition-id 2 \
-            --open""",
-        warn=True,
-        hide=True,
-    )
-    if result:
-        result_object = json.loads(result.stdout)
-        # print (json.dumps (result_object, indent=4))
-        release_id = result_object["id"]
-        release_devops_url = (
-            "https://dev.azure.com/nhsuk/dct.campaign-resource-centre-v3/_releaseProgress?_a=release-pipeline-progress&releaseId=%s"
-            % release_id
-        )
-        print(
-            "Database dump pipeline triggered - review progress at %s"
-            % release_devops_url
-        )
-    else:
-        print(
-            "Pipeline trigger failed with error code %d: %s"
-            % (result.exited, result.stderr)
-        )
-        print(
-            "Please ensure that you are logged in az cli and have the az cli extension installed."
-        )
 
 
 def delete_local_renditions(c, local_database_name=LOCAL_DATABASE_NAME):


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1426

## Description

- Move db dumps from digitalcampaignsstorage storage account to new dctcrccmsbackupsdevuks storage account
- Use `auth-mode = login` to upload to dctcrccmsbackupsdevuks
- Update `fab sync-db <env>` command to remove storage key and use new storage account

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
