### PR TITLE
CV-1425 - Create proper dev storage container, consume client_id from identity

### DIFF
--- a/terraform/src/common/container_app_environment.tf
+++ b/terraform/src/common/container_app_environment.tf
@@ -1,5 +1,5 @@
 module "container_app_env" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.container-app-env?ref=1.1.2"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.container-app-env?ref=1.2.0"
 
   count = var.deploy_container_apps ? 1 : 0
 

--- a/terraform/src/common/container_apps.tf
+++ b/terraform/src/common/container_apps.tf
@@ -34,4 +34,5 @@ module "aca_wagtail" {
   alerts_action_group_id = module.container_app_env[0].alerts_action_group_id
   dr_origin              = var.dr_deployed ? data.azurerm_container_app.dr[0].ingress[0].fqdn : null
   container_resources    = var.container_resources
+  trim_container_app_resource_names = true
 }

--- a/terraform/src/common/container_apps.tf
+++ b/terraform/src/common/container_apps.tf
@@ -1,5 +1,5 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=1.4.3"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=2.0.1"
 
   # dev container apps get deployed separately to allow for many transient environments
   count = var.deploy_container_apps && var.env != "dev" ? 1 : 0
@@ -8,7 +8,6 @@ module "aca_wagtail" {
   location                          = data.azurerm_resource_group.rg.location
   org                               = local.org
   app                               = local.app
-  short_app_name                    = local.short_app_name
   app_image                         = "dct/crc-cms:${var.crc_cms_version}"
   haproxy_image                     = "dct/haproxy-front-door:1.0.1"
   container_registry                = "dctcampaignsacrproduks.azurecr.io"
@@ -19,14 +18,20 @@ module "aca_wagtail" {
   frontdoor_profile                 = var.location == "uks" ? module.network_spoke[0].frontdoor : data.azurerm_cdn_frontdoor_profile.frontdoor[0]
   frontdoor_firewall_policy_enabled = true
   frontdoor_firewall_policy_id      = module.network_spoke[0].waf_policy_id
-  key_vault_id                      = module.container_app_env[0].key_vault_id
   username                          = var.username
   sha_512_password                  = var.sha_512_password #gitleaks:allow not actually the password
   init_args                         = local.init_args
   init_config                       = local.init_config
-  init_secrets                      = local.init_secrets
-  app_secrets                       = local.app_secrets
-  alerts_action_group_id            = module.container_app_env[0].alerts_action_group_id
-  dr_origin                         = var.dr_deployed ? data.azurerm_container_app.dr[0].ingress[0].fqdn : null
-  container_resources               = var.container_resources
+  init_secrets = [
+    for secret in azurerm_key_vault_secret.wagtail :
+    secret if contains(local.init_secrets, upper(replace(secret.name, "-", "_")))
+  ]
+  app_config = local.app_config
+  app_secrets = [
+    for secret in azurerm_key_vault_secret.wagtail :
+    secret if contains(local.app_secrets, upper(replace(secret.name, "-", "_")))
+  ]
+  alerts_action_group_id = module.container_app_env[0].alerts_action_group_id
+  dr_origin              = var.dr_deployed ? data.azurerm_container_app.dr[0].ingress[0].fqdn : null
+  container_resources    = var.container_resources
 }

--- a/terraform/src/common/container_apps.tf
+++ b/terraform/src/common/container_apps.tf
@@ -31,8 +31,8 @@ module "aca_wagtail" {
     for secret in azurerm_key_vault_secret.wagtail :
     secret if contains(local.app_secrets, upper(replace(secret.name, "-", "_")))
   ]
-  alerts_action_group_id = module.container_app_env[0].alerts_action_group_id
-  dr_origin              = var.dr_deployed ? data.azurerm_container_app.dr[0].ingress[0].fqdn : null
-  container_resources    = var.container_resources
+  alerts_action_group_id            = module.container_app_env[0].alerts_action_group_id
+  dr_origin                         = var.dr_deployed ? data.azurerm_container_app.dr[0].ingress[0].fqdn : null
+  container_resources               = var.container_resources
   trim_container_app_resource_names = true
 }

--- a/terraform/src/common/env/dev-uks.tfvars
+++ b/terraform/src/common/env/dev-uks.tfvars
@@ -4,6 +4,11 @@ location        = "uks"
 resource_group  = "dct-crccms-rg-dev-uks"
 subscription_id = "f8a1a507-8a52-452c-84d4-ad20a8648f58"
 
+storage = {
+  account   = "campaignsstrgdevuks"
+  container = "campaign-resource-centre-v3-review"
+}
+
 deploy_container_apps = true
 network_address_space = "10.1.8.0/22"
 

--- a/terraform/src/common/env/int-uks.tfvars
+++ b/terraform/src/common/env/int-uks.tfvars
@@ -34,5 +34,6 @@ container_resources = {
     min_replicas = 1
     max_replicas = 3
     concurrency  = 50
-  }
+  },
+  publish = null
 }

--- a/terraform/src/common/env/prod-uks.tfvars
+++ b/terraform/src/common/env/prod-uks.tfvars
@@ -36,5 +36,6 @@ container_resources = {
     min_replicas = 3
     max_replicas = 12
     concurrency  = 75
-  }
+  },
+  publish = null
 }

--- a/terraform/src/common/env/prod-ukw.tfvars
+++ b/terraform/src/common/env/prod-ukw.tfvars
@@ -28,5 +28,6 @@ container_resources = {
     min_replicas = 2
     max_replicas = 12
     concurrency  = 75
-  }
+  },
+  publish = null
 }

--- a/terraform/src/common/env/stag-uks.tfvars
+++ b/terraform/src/common/env/stag-uks.tfvars
@@ -38,5 +38,6 @@ container_resources = {
     min_replicas = 1
     max_replicas = 3
     concurrency  = 75
-  }
+  },
+  publish = null
 }

--- a/terraform/src/common/env/stag-ukw.tfvars
+++ b/terraform/src/common/env/stag-ukw.tfvars
@@ -30,5 +30,6 @@ container_resources = {
     min_replicas = 1
     max_replicas = 3
     concurrency  = 100
-  }
+  },
+  publish = null
 }

--- a/terraform/src/common/key_vault_secrets.tf
+++ b/terraform/src/common/key_vault_secrets.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault_secret" "wagtail" {
-  # each dev instance gets it's own secrets copied as part of the deployment pipeline
+  # each dev instance gets its own secrets copied as part of the deployment pipeline
   for_each = var.env != "dev" ? toset(concat(local.app_secrets, local.init_secrets)) : toset([])
 
   name         = replace(lower(each.key), "_", "-")

--- a/terraform/src/common/key_vault_secrets.tf
+++ b/terraform/src/common/key_vault_secrets.tf
@@ -1,0 +1,17 @@
+resource "azurerm_key_vault_secret" "wagtail" {
+  # each dev instance gets it's own secrets copied as part of the deployment pipeline
+  for_each = var.env != "dev" ? toset(concat(local.app_secrets, local.init_secrets)) : toset([])
+
+  name         = replace(lower(each.key), "_", "-")
+  value        = "EMPTY"
+  key_vault_id = module.container_app_env[0].key_vault_id
+
+  lifecycle {
+    ignore_changes = [value, tags]
+  }
+}
+
+moved {
+  from = module.aca_wagtail[0].azurerm_key_vault_secret.wagtail
+  to   = azurerm_key_vault_secret.wagtail
+}

--- a/terraform/src/common/locals.tf
+++ b/terraform/src/common/locals.tf
@@ -83,12 +83,16 @@ locals {
     "WEB_CONCURRENCY",
   ]
   init_config = {}
+
+  app_config = {
+    AZURE_CLIENT_ID = module.container_app_env[0].identity.client_id
+  }
+
   app_secrets = [
     "ADOBE_TRACKING_URL",
     "ALLOWED_HOSTS",
     "AZURE_ACCOUNT_KEY",
     "AZURE_ACCOUNT_NAME",
-    "AZURE_CLIENT_ID",
     "AZURE_CONTAINER",
     "AZURE_CUSTOM_DOMAIN",
     "AZURE_SEARCH_ACCESS_KEY",

--- a/terraform/src/common/locals.tf
+++ b/terraform/src/common/locals.tf
@@ -26,7 +26,7 @@ locals {
   storage_container = var.storage != null ? { "${var.storage.container}" : var.storage.account } : {}
 
   non_prod_storage_container_ids = {
-    "review"      = "/subscriptions/6a1350a9-9b14-4f69-9653-c8ccec15b48e/resourceGroups/dct-crccms-rg-int-uks/providers/Microsoft.Storage/storageAccounts/campaignsstrgintuks/blobServices/default/containers/campaign-resouce-centre-v3-review",
+    "review"      = "/subscriptions/f8a1a507-8a52-452c-84d4-ad20a8648f58/resourceGroups/dct-crccms-rg-dev-uks/providers/Microsoft.Storage/storageAccounts/campaignsstrgdevuks/blobServices/default/containers/campaign-resource-centre-v3-review",
     "integration" = "/subscriptions/6a1350a9-9b14-4f69-9653-c8ccec15b48e/resourceGroups/dct-crccms-rg-int-uks/providers/Microsoft.Storage/storageAccounts/campaignsstrgintuks/blobServices/default/containers/campaign-resouce-centre-v3-integration",
     "staging"     = "/subscriptions/575a903b-95a0-4f6c-b80e-4a1e0a04da75/resourceGroups/dct-crccms-rg-stag-uks/providers/Microsoft.Storage/storageAccounts/campaignsstrgstaguks/blobServices/default/containers/campaign-resource-centre-v3-staging"
   }

--- a/terraform/src/common/storage_account.tf
+++ b/terraform/src/common/storage_account.tf
@@ -47,24 +47,6 @@ resource "azurerm_role_assignment" "storage_blob_contributor_apps_identity" {
   principal_type       = "ServicePrincipal"
 }
 
-moved {
-  from = azurerm_role_assignment.storage_blob_contributor_dev_identity
-  to   = azurerm_role_assignment.storage_blob_contributor_dev_apps_identity
-}
-
-resource "azurerm_role_assignment" "storage_blob_contributor_dev_apps_identity" {
-  count = var.env == "int" ? 1 : 0
-
-  principal_id         = "84ef78f0-e0f9-4844-8d13-d1d494b7f42e" # dct-crccms-id-dev managed identity
-  role_definition_name = "Storage Blob Data Contributor"
-  scope                = local.non_prod_storage_container_ids["review"]
-  principal_type       = "ServicePrincipal"
-
-  lifecycle {
-    ignore_changes = [condition, condition_version, skip_service_principal_aad_check]
-  }
-}
-
 resource "azurerm_role_assignment" "non_prod_storage_blob_contributor_pipeline_identity" {
   for_each = var.env == "prod" && var.location == "uks" ? local.non_prod_storage_container_ids : {}
 

--- a/terraform/src/common/variables.tf
+++ b/terraform/src/common/variables.tf
@@ -108,6 +108,10 @@ variable "container_resources" {
       min_replicas = number
       max_replicas = number
       concurrency  = number
+    }),
+    publish = object({
+      cpu    = number
+      memory = string
     })
   })
 }

--- a/terraform/src/review/data.tf
+++ b/terraform/src/review/data.tf
@@ -21,3 +21,10 @@ data "azurerm_key_vault" "wagtail" {
   name                = "${local.org}-${local.short_app_name}-kv-app-${local.environment}-${local.region}"
   resource_group_name = data.azurerm_resource_group.wagtail.name
 }
+
+data "azurerm_key_vault_secret" "wagtail" {
+  for_each = toset(concat(local.app_secrets, local.init_secrets))
+
+  name         = "${var.dev_instance}--${replace(lower(each.key), "_", "-")}"
+  key_vault_id = data.azurerm_key_vault.wagtail.id
+}

--- a/terraform/src/review/locals.tf
+++ b/terraform/src/review/locals.tf
@@ -43,12 +43,15 @@ locals {
   init_config = {
   }
 
+  app_config = {
+    AZURE_CLIENT_ID = data.azurerm_user_assigned_identity.wagtail.client_id
+  }
+
   app_secrets = [
     "ADOBE_TRACKING_URL",
     "ALLOWED_HOSTS",
     "AZURE_ACCOUNT_KEY",
     "AZURE_ACCOUNT_NAME",
-    "AZURE_CLIENT_ID",
     "AZURE_CONTAINER",
     "AZURE_CUSTOM_DOMAIN",
     "AZURE_SEARCH_ACCESS_KEY",
@@ -120,6 +123,7 @@ locals {
       min_replicas = 1
       max_replicas = 3
       concurrency  = 10
-    }
+    },
+    publish = null
   }
 }

--- a/terraform/src/review/main.tf
+++ b/terraform/src/review/main.tf
@@ -1,10 +1,9 @@
 module "aca_wagtail" {
-  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=1.4.3"
+  source = "git::https://github.com/nhsuk/dct.terraform-modules.wagtail-container-apps?ref=2.0.1"
 
   environment                  = local.environment
   org                          = local.org
   app                          = local.app
-  short_app_name               = local.short_app_name
   app_image                    = "dct/crc-cms:${var.crc_cms_version}"
   haproxy_image                = "dct/haproxy-front-door:1.0.1"
   container_registry           = "dctcampaignsacrproduks.azurecr.io"
@@ -14,15 +13,20 @@ module "aca_wagtail" {
   container_app_environment_id = data.azurerm_container_app_environment.wagtail.id
   identity_id                  = data.azurerm_user_assigned_identity.wagtail.id
   frontdoor_profile            = data.azurerm_cdn_frontdoor_profile.wagtail
-  key_vault_id                 = data.azurerm_key_vault.wagtail.id
   username                     = var.username
   sha_512_password             = var.sha_512_password #gitleaks:allow not actually the password
   init_args                    = local.init_args
   init_config                  = local.init_config
-  init_secrets                 = local.init_secrets
-  app_secrets                  = local.app_secrets
-  alerts_action_group_id       = null
-  enable_alerts                = false
-  existing_secrets             = true
-  container_resources          = local.container_resources
+  init_secrets = [
+    for secret in data.azurerm_key_vault_secret.wagtail :
+    secret if contains(local.init_secrets, upper(replace(replace(secret.name, "${var.dev_instance}--", ""), "-", "_")))
+  ]
+  app_config = local.app_config
+  app_secrets = [
+    for secret in data.azurerm_key_vault_secret.wagtail :
+    secret if contains(local.app_secrets, upper(replace(replace(secret.name, "${var.dev_instance}--", ""), "-", "_")))
+  ]
+  alerts_action_group_id = null
+  enable_alerts          = false
+  container_resources    = local.container_resources
 }


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1425

## Description

- Move key vault secret management out of the wagtail module and into the parent CRC Terraform
- Bump the wagtail container apps module from v1.4.3 to v2.0.1
- Bump the wagtail container apps env module to v1.2.0 (to consume the `identity` output)
- Pass `AZURE_CLIENT_ID` as a plain environment variable via app_config instead of storing it as a key vault secret
- Add publish option to the container resources variable for all environments
- Create a dedicated dev storage account (campaignsstrgdevuks) with its own blob container, replacing the old setup where dev borrowed int's storage account and needed a cross-subscription stuff

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
