### PR TITLE
[CV-1426] Remove prod dumps from db sync pipeline and storage account

### DIFF
--- a/azure-pipeline-templates/db-sync.yml
+++ b/azure-pipeline-templates/db-sync.yml
@@ -4,20 +4,7 @@ pool:
 trigger: none
 pr: none
 
-# daily midnight backup midnight - this will not run any of the syncing jobs, only the backup
-schedules:
-  - cron: '0 0 * * *'
-    displayName: Daily midnight build
-    always: true
-    branches:
-      include:
-        - main
-
 parameters:
-  - name: backupProduction
-    type: boolean
-    default: true
-    displayName: Backup Production DB
   - name: syncToReview
     type: boolean
     default: false
@@ -52,19 +39,6 @@ stages:
               SecretsFilter: db-pass, db-name, db-host, db-user
           - template: templates/db-sync-download-dump.yaml
             parameters:
-              environment: production
-
-  - stage: UploadProdDumpToBlob
-    displayName: Backup Production Database
-    dependsOn:
-      - CopyFromProdDB
-    condition: and(succeeded(), eq('${{ parameters.backupProduction }}', 'true'))
-    jobs:
-      - job: DumpUpload
-        steps:
-          - template: templates/db-sync-upload-blob.yaml
-            parameters:
-              useArtifact: true
               environment: production
 
   - stage: CopyToReviewDB

--- a/azure-pipeline-templates/templates/db-sync-download-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-dump.yaml
@@ -1,7 +1,6 @@
 steps:
 - script: |
-    set -x
-    set -e
+    set -ex
     docker run \
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \

--- a/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
+++ b/azure-pipeline-templates/templates/db-sync-download-users-dump.yaml
@@ -1,7 +1,6 @@
 steps:
 - script: |
-    set -x
-    set -e
+    set -ex
     docker run \
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \

--- a/azure-pipeline-templates/templates/db-sync-restore-users.yaml
+++ b/azure-pipeline-templates/templates/db-sync-restore-users.yaml
@@ -1,7 +1,7 @@
 steps:
 - script: |
-    mkdir psql_commands_scripts
     set -e
+    mkdir -p psql_commands_scripts
     docker run \
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \
@@ -23,8 +23,8 @@ steps:
   displayName: 'Make drop user constraints script'
 
 - script: |
-    mkdir psql_commands_scripts
     set -e
+    mkdir -p psql_commands_scripts
     docker run \
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \
@@ -65,8 +65,8 @@ steps:
   displayName: 'Make add modified constraints script'
 
 - script: |
-    mkdir psql_commands_scripts
     set -e
+    mkdir -p psql_commands_scripts
     docker run \
       -e PGHOST="$(db-host)" \
       -e PGPASSWORD="$(db-pass)" \

--- a/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
+++ b/azure-pipeline-templates/templates/db-sync-upload-blob.yaml
@@ -17,8 +17,7 @@ steps:
     scriptType: bash
     scriptLocation: inlineScript
     inlineScript: |
-      set -x
-      set -e
+      set -xe
 
       # Rename the data dump to contain timestamp before upload
       mv $ENVIRONMENT-db-dump.dump db-dump-$(currentDatestamp.Datestamp).dump
@@ -28,8 +27,7 @@ steps:
         --account-name dctcrccmsbackupsdevuks \
         --container-name $ENVIRONMENT \
         --file db-dump-$(currentDatestamp.Datestamp).dump \
-        --name db-dump-$(currentDatestamp.Datestamp).dump \
-        --auth-mode login
+        --name db-dump-$(currentDatestamp.Datestamp).dump
   name: BlobStorageBackup
   displayName: Backup to Blob Storage
   env:

--- a/terraform/src/common/storage_account.tf
+++ b/terraform/src/common/storage_account.tf
@@ -82,9 +82,8 @@ resource "azurerm_storage_account" "crc_cms_backups" {
   }
 }
 
-#trivy:ignore:avd-azu-0007 storage container public access is enabled as it serves the assets for the website
 resource "azurerm_storage_container" "crc_cms_backups" {
-  for_each = var.env == "dev" ? toset(["review", "integration", "staging", "production"]) : toset([])
+  for_each = var.env == "dev" ? toset(["review", "integration", "staging"]) : toset([])
 
   name                  = each.value
   storage_account_id    = azurerm_storage_account.crc_cms_backups[0].id


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1426

## Description

Previously daily database backups were done using this pipeline to a storage account, however there is no need for this now as we have point-in-time backups and daily vaulted backups so we can remove it.
This PR:
* 🚮 removes the production storage container hosting prod db dumps
* 🗑️ removes uploading prod db to storage account
* ⏰ removes daily schedule, can just be run on demand to sync envs
* 🧹 tidies bash
* 🐞 removes incorrect trivy ignore

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
