### PR TITLE
[CV-1447] Fix add basket to find correct resource item to add to basket

### DIFF
--- a/campaignresourcecentre/baskets/views.py
+++ b/campaignresourcecentre/baskets/views.py
@@ -28,8 +28,12 @@ def _add_item(request):
     basket = Basket(request.session)
     payload = request.POST
     sku = payload.get("sku")
-    if sku:
-        item_obj = ResourceItem.objects.filter(sku=sku).first()
+    resource_page_id = payload.get("resource_page_id")
+
+    if sku and resource_page_id:
+        item_obj = ResourceItem.objects.filter(
+            sku=sku, resource_page_id=resource_page_id
+        ).first()
     else:
         item_obj = None
     if item_obj:

--- a/terraform/src/review/main.tf
+++ b/terraform/src/review/main.tf
@@ -27,7 +27,8 @@ module "aca_wagtail" {
     for secret in data.azurerm_key_vault_secret.wagtail :
     secret if contains(local.app_secrets, upper(replace(replace(secret.name, "${var.dev_instance}--", ""), "-", "_")))
   ]
-  alerts_action_group_id = null
-  enable_alerts          = false
-  container_resources    = local.container_resources
+  alerts_action_group_id            = null
+  enable_alerts                     = false
+  container_resources               = local.container_resources
+  trim_container_app_resource_names = true
 }


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1447

## Description

Currently the filter to find the correct `ResourceItem` to add to the basket does not take into account duplicate items with the same SKU on different pages. This PR:
* 🐞 fixes the resource item lookup to include the resource page ID along with the SKU
* 🐛 adds resource name trim to review env

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
