### PR TITLE
Add --disableNodeAudit to OWASP tasks to workaround issue

### DIFF
--- a/azure-pipeline-templates/test.yml
+++ b/azure-pipeline-templates/test.yml
@@ -47,8 +47,7 @@ steps:
   inputs:
     workingDirectory: $(Pipeline.Workspace)/owasp
     filePath: $(Pipeline.Workspace)/owasp/run_owasp_scanner.sh
-    arguments: '--scan "$(System.DefaultWorkingDirectory)" --suppression "$(System.DefaultWorkingDirectory)/owasp-suppression.xml" --failOnCVSS ${{ parameters.OWASPFailScore }} --project "$(Build.Repository.Name)" --disableOssIndex --out "$(System.DefaultWorkingDirectory)/dependency-scan-results" --format HTML --format JUNIT --format JSON'
-  continueOnError: true
+    arguments: '--scan "$(System.DefaultWorkingDirectory)" --suppression "$(System.DefaultWorkingDirectory)/owasp-suppression.xml" --failOnCVSS ${{ parameters.OWASPFailScore }} --project "$(Build.Repository.Name)" --disableOssIndex --disableNodeAudit --out "$(System.DefaultWorkingDirectory)/dependency-scan-results" --format HTML --format JUNIT --format JSON'
 - task: PublishTestResults@2
   displayName: "Publish OWASP dependency check results"
   condition: and(succeededOrFailed(), eq('${{ parameters.DisableOwaspDependencyCheck }}', false))
@@ -56,7 +55,6 @@ steps:
     testRunner: JUnit
     testResultsFiles: $(System.DefaultWorkingDirectory)/dependency-scan-results/dependency-check-junit.xml
     testRunTitle: "OWASP Dependency check"
-  continueOnError: true
 - script: |
     docker compose run --no-deps --rm web python manage.py makemigrations --check --dry-run --no-input
   displayName: Check for missing migrations

--- a/azure-pipeline-templates/test.yml
+++ b/azure-pipeline-templates/test.yml
@@ -44,7 +44,6 @@ steps:
 - task: Bash@3
   displayName: Run OWASP Dependency Check
   condition: and(succeeded(), eq('${{ parameters.DisableOwaspDependencyCheck }}', false))
-  continueOnError: false
   inputs:
     workingDirectory: $(Pipeline.Workspace)/owasp
     filePath: $(Pipeline.Workspace)/owasp/run_owasp_scanner.sh

--- a/azure-pipeline-templates/test.yml
+++ b/azure-pipeline-templates/test.yml
@@ -49,6 +49,7 @@ steps:
     workingDirectory: $(Pipeline.Workspace)/owasp
     filePath: $(Pipeline.Workspace)/owasp/run_owasp_scanner.sh
     arguments: '--scan "$(System.DefaultWorkingDirectory)" --suppression "$(System.DefaultWorkingDirectory)/owasp-suppression.xml" --failOnCVSS ${{ parameters.OWASPFailScore }} --project "$(Build.Repository.Name)" --disableOssIndex --out "$(System.DefaultWorkingDirectory)/dependency-scan-results" --format HTML --format JUNIT --format JSON'
+  continueOnError: true
 - task: PublishTestResults@2
   displayName: "Publish OWASP dependency check results"
   condition: and(succeededOrFailed(), eq('${{ parameters.DisableOwaspDependencyCheck }}', false))
@@ -56,6 +57,7 @@ steps:
     testRunner: JUnit
     testResultsFiles: $(System.DefaultWorkingDirectory)/dependency-scan-results/dependency-check-junit.xml
     testRunTitle: "OWASP Dependency check"
+  continueOnError: true
 - script: |
     docker compose run --no-deps --rm web python manage.py makemigrations --check --dry-run --no-input
   displayName: Check for missing migrations


### PR DESCRIPTION
## Jira tickets resolved by this PR

N/A

## Description

Add --disableNodeAudit to OWASP tasks due to issues:
https://dev.azure.com/nhsuk/dct.campaign-resource-centre-v3/_build/results?buildId=353622&view=logs&j=5586873e-3678-5ddf-4e42-2d9415ba6844&t=ebf7c3dd-51e2-5ae8-5263-bba3deec90ba&s=a6acec94-966c-5529-532c-5cb909eba617

## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
