### PR TITLE
Remove unnecessary py3-pip install causing a vulnerability as the base image already includes pip

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,20 +1,14 @@
 ignore:
   - vulnerability: CVE-2026-6100
     reason: Awaiting latest python3.12 to be included in alpine with fix
-    package:
-      name: python3
   - vulnerability: CVE-2026-4519
     reason: Awaiting latest python3.12 to be included in alpine with fix
-    package:
-      name: python3
   - vulnerability: CVE-2026-4786
     reason: Awaiting fix to be implemented
-    package:
-      name: python3
   - vulnerability: CVE-2025-13836
     reason: Awaiting fix to be implemented
-    package:
-      name: python3
+  - vulnerability: CVE-2026-3298
+    reason: Awaiting fix to be implemented
   - vulnerability: CVE-2026-3441
     reason: Awaiting fix to be created and included in alpine
     package:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm run build:prod
 FROM python:3.12-alpine AS backend
 
 RUN apk update \
-    && apk --no-cache add bash curl linux-headers postgresql-dev py3-pip  \
+    && apk --no-cache add bash curl linux-headers postgresql-dev  \
     && pip3 install --upgrade pip setuptools
 
 ARG POETRY_HOME=/opt/poetry

--- a/UnitTestDockerfile
+++ b/UnitTestDockerfile
@@ -12,10 +12,6 @@ COPY ./campaignresourcecentre/static_src/ ./campaignresourcecentre/static_src/
 RUN npm run build:prod
 
 
-# We use Debian images because they are considered more stable than the alpine
-# ones becase they use a different C compiler. Debian images also come with
-# all useful packages required for image manipulation out of the box. They
-# however weight a lot, approx. up to 1.5GiB per built image.
 FROM python:3.12-alpine AS backend
 RUN apk update
 RUN apk add curl postgresql-dev bash linux-headers

--- a/UnitTestDockerfile
+++ b/UnitTestDockerfile
@@ -18,7 +18,7 @@ RUN npm run build:prod
 # however weight a lot, approx. up to 1.5GiB per built image.
 FROM python:3.12-alpine AS backend
 RUN apk update
-RUN apk add curl postgresql-dev bash linux-headers py3-pip
+RUN apk add curl postgresql-dev bash linux-headers
 RUN pip3 install --upgrade pip setuptools
 
 ARG POETRY_HOME=/opt/poetry


### PR DESCRIPTION
## Jira tickets resolved by this PR

- https://ukhsa.atlassian.net/browse/CV-1234

## Description
Removed the package name in the existing suppressions because Grype reports these CVEs under both python3 (APK) and python (binary) - the old package: `name: python3` filter only matched the APK finding, leaving the binary detection unsuppressed.

Security issues:
`CVE-2026-3298 (High)`
Removed the redundant py3-pip package which pulled in the vulnerable `python3@3.12.13-r0` APK as a dependency. The `python:3.12-alpine` base image we use already provides pip. Suppression kept in though as the Python binary in the base image also carries this CVE until 3.12.14 is released.


## Developer Checklist

Before requesting approvals for this PR (and after pushing more changes), for each of the following tasks, please confirm completion or detail why it doesn't apply:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] Jira ticket has up-to-date ACs and necessary test documentation
